### PR TITLE
Support all plugin types

### DIFF
--- a/actions/entrypoint.sh
+++ b/actions/entrypoint.sh
@@ -17,7 +17,7 @@ function _convert() {
 
     shopt -s nocasematch
     for plugin in $(echo $plugin_packages | tr ',' ' '); do
-        if [[ "$plugin" == pysigma-backend-* ]]; then
+        if [[ "$plugin" == pysigma-* ]]; then
             valid_plugins+=("$plugin")
         else
             echo "Error: Invalid plugin name: $plugin"


### PR DESCRIPTION
This PR fixes validation of the plugin package name to include pipelines and other types of plugins, not just backend ones.