### PR TITLE
Remove boolean actions to simplify CLI args

### DIFF
--- a/actions/convert/main.py
+++ b/actions/convert/main.py
@@ -4,9 +4,10 @@ This script is used to convert Sigma rules to the target format per
 each conversion object in the config.
 ---
 usage: main.py [-h] [--config CONFIG] [--path-prefix PATH_PREFIX]
-               [--render-traceback | --no-render-traceback]
-               [--pretty-print | --no-pretty-print] [--all-rules | --no-all-rules]
-               [--changed-files CHANGED_FILES] [--deleted-files DELETED_FILES]
+               [--render-traceback RENDER_TRACEBACK]
+               [--pretty-print PRETTY_PRINT] [--all-rules ALL_RULES]
+               [--changed-files CHANGED_FILES]
+               [--deleted-files DELETED_FILES]
 
 Sigma CLI Conversion
 
@@ -15,11 +16,11 @@ options:
   --config CONFIG       Path to config YAML file (default: ./config.yaml)
   --path-prefix PATH_PREFIX
                         The path prefix to use for input files (default: .)
-  --render-traceback, --no-render-traceback
+  --render-traceback RENDER_TRACEBACK
                         Render traceback on error (default: False)
-  --pretty-print, --no-pretty-print
+  --pretty-print PRETTY_PRINT
                         Pretty print the converted files (default: False)
-  --all-rules, --no-all-rules
+  --all-rules ALL_RULES
                         Convert all rules (default: False)
   --changed-files CHANGED_FILES
                         List of changed files (default: )

--- a/actions/convert/settings.py
+++ b/actions/convert/settings.py
@@ -45,19 +45,16 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--render-traceback",
-        action=argparse.BooleanOptionalAction,
         help="Render traceback on error",
         default=os.environ.get("RENDER_TRACEBACK", "false").lower() in TRUE_VALUES,
     )
     parser.add_argument(
         "--pretty-print",
-        action=argparse.BooleanOptionalAction,
         help="Pretty print the converted files",
         default=os.environ.get("PRETTY_PRINT", "false").lower() in TRUE_VALUES,
     )
     parser.add_argument(
         "--all-rules",
-        action=argparse.BooleanOptionalAction,
         help="Convert all rules",
         default=os.environ.get("ALL_RULES", "false").lower() in TRUE_VALUES,
     )


### PR DESCRIPTION
Changes made in #46 yesterday created two sets of CLI args for true/false using `--flag` and `--no-flag` format. This makes things harder to integrate with our existing setup (and integration with sigma-internal). So, I removed the boolean actions to make the flags work like before: `--flag true/false`.