### PR TITLE
Fix the unit used for time window

### DIFF
--- a/actions/integrate/definitions/alert_types.go
+++ b/actions/integrate/definitions/alert_types.go
@@ -2,6 +2,7 @@ package definitions
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -146,6 +147,46 @@ type RelativeTimeRange struct {
 
 // Duration represents a time duration
 type Duration time.Duration
+
+func (d Duration) String() string {
+	return time.Duration(d).String()
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).Seconds())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		*d = Duration(time.Duration(value) * time.Second)
+		return nil
+	default:
+		return fmt.Errorf("invalid duration %v", v)
+	}
+}
+
+func (d Duration) MarshalYAML() (any, error) {
+	return time.Duration(d).Seconds(), nil
+}
+
+func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
+	var v any
+	if err := unmarshal(&v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case int:
+		*d = Duration(time.Duration(value) * time.Second)
+		return nil
+	default:
+		return fmt.Errorf("invalid duration %v", v)
+	}
+}
 
 // Provenance represents the provenance of the alert rule
 type Provenance string

--- a/actions/integrate/integrator.go
+++ b/actions/integrate/integrator.go
@@ -341,7 +341,7 @@ func (i *Integrator) ConvertToAlert(rule *definitions.ProvisionedAlertRule, quer
 	if err != nil {
 		return fmt.Errorf("error parsing time window: %v", err)
 	}
-	timerange := definitions.RelativeTimeRange{From: definitions.Duration(duration), To: definitions.Duration(time.Duration(0))}
+	timerange := definitions.RelativeTimeRange{From: definitions.Duration(duration.Seconds()), To: definitions.Duration(time.Duration(0))}
 
 	queryData := make([]definitions.AlertQuery, 0, len(queries)+2)
 	refIds := make([]string, len(queries))


### PR DESCRIPTION
When reducing the amount of code taken directly from Grafana Alerting, the unit used for the alert data time window was inadvertently changed from seconds to nanoseconds. This reverts that change.