### PR TITLE
Zizmor: Enable pedantic mode and fix reported issues

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,6 +11,8 @@ on:
       - ".github/workflows/**"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   actionlint:
     name: Actionlint
@@ -19,12 +21,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 
       - name: Run actionlint
-        uses: raven-actions/actionlint@v2
+        uses: raven-actions/actionlint@01fce4f43a270a612932cb1c64d40505a029f821 #v2.0.0
         with:
           files: ".github/workflows/*.yml,.github/workflows/*.yaml"
           fail-on-error: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,26 +8,27 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build and Push"
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 #v6.15.0
         if: github.event_name == 'pull_request'
         with:
           context: ./actions
@@ -36,7 +37,7 @@ jobs:
             ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:sha-${{ github.event.pull_request.head.sha }}
           push: true
       - name: "Build and Push"
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 #v6.15.0
         if: github.event_name == 'push'
         with:
           context: ./actions

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -11,6 +11,8 @@ on:
       - "actions/Dockerfile"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   hadolint:
     name: Hadolint
@@ -19,12 +21,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 
       - name: Run Hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf #v3.1.0
         with:
           dockerfile: actions/Dockerfile
           failure-threshold: warning

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,6 +11,8 @@ on:
       - "actions/entrypoint.sh"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   shellcheck:
     name: ShellCheck
@@ -19,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   golangci-lint:
     name: Run golangci-lint
@@ -18,18 +20,18 @@ jobs:
       checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0
         with:
           go-version: "1.24.1"
           cache: false
 
       - name: Run golangci-lint on integrate project
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 #v6.5.2
         with:
           version: v1.64.8
           working-directory: actions/integrate
@@ -37,7 +39,7 @@ jobs:
           install-mode: "goinstall"
 
       - name: Run golangci-lint on deploy project
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 #v6.5.2
         with:
           version: v1.64.8
           working-directory: actions/deploy
@@ -51,12 +53,12 @@ jobs:
       checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 
       - name: Set up Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 #v5.5.0
         with:
           python-version: "3.10"
 
@@ -90,12 +92,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0
         with:
           go-version: "1.24.1"
           cache: false
@@ -120,12 +122,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0
         with:
           go-version: "1.24.1"
           cache: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,6 +9,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   security-scan:
     runs-on: ubuntu-latest
@@ -17,7 +19,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 
@@ -27,4 +29,4 @@ jobs:
 
       - name: Run zizmor on all files
         run: |
-          zizmor .
+          zizmor -p .

--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -40,7 +40,7 @@ runs:
   using: "composite"
   steps:
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -48,7 +48,7 @@ runs:
     - name: Get Last Commit or base_ref
       if: ${{ github.event_name == 'pull_request' && inputs.changed_files_from_base == 'false' }}
       id: commits
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         ACTIONS_USERNAME: ${{ inputs.actions_username }}
       with:
@@ -80,7 +80,7 @@ runs:
           };
     - name: Select Commit
       id: previous-commit
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         COMMIT: ${{ steps.commits.outputs.result }}
       with:
@@ -91,7 +91,7 @@ runs:
         result-encoding: string
     - name: Select First Commit
       id: first-commit
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         COMMIT: ${{ steps.commits.outputs.result }}
       with:
@@ -102,7 +102,7 @@ runs:
         result-encoding: string
     - name: Select Last Commit
       id: last-commit
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         COMMIT: ${{ steps.commits.outputs.result }}
       with:
@@ -165,7 +165,7 @@ runs:
 
     - name: Comment Conversions
       id: comment-conversions
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         BASE_REF: ${{ steps.first-commit.outputs.result || github.base_ref || github.event.pull_request.base.ref || 'HEAD' }}
         CHANGED_FILES: ${{ steps.generate-comment-data.outputs.changed_files }}

--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: "Checkout repository (fetch-depth: 0)"
       id: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 0 # Important to ensure we'll have all the commits when a merge includes multiple
     - name: "Detect changed files"
@@ -44,7 +44,7 @@ runs:
       with:
         output_renamed_files_as_deleted_and_added: "true"
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -92,7 +92,7 @@ runs:
         echo "grafana_instance=${GRAFANA_INSTANCE}" >> $GITHUB_OUTPUT
     - name: Comment Status
       if: success() && github.event_name == 'push'
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         ALERTS_CREATED: ${{ steps.output.outputs.alerts_created }}
         ALERTS_UPDATED: ${{ steps.output.outputs.alerts_updated }}
@@ -169,7 +169,7 @@ runs:
             }
     - name: Comment Status
       if: failure() && github.event_name == 'push'
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       with:
           script: |
             const associatedPrs = await github.rest.repos.listPullRequestsAssociatedWithCommit({

--- a/actions/integrate/action.yml
+++ b/actions/integrate/action.yml
@@ -56,7 +56,7 @@ runs:
   using: "composite"
   steps:
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -64,7 +64,7 @@ runs:
     - name: Get Last Commit or base_ref
       if: ${{ github.event_name == 'pull_request' && inputs.changed_files_from_base == 'false' }}
       id: commits
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         ACTIONS_USERNAME: ${{ inputs.actions_username }}
       with:
@@ -96,7 +96,7 @@ runs:
           };
     - name: Select Commit
       id: previous-commit
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         COMMIT: ${{ steps.commits.outputs.result }}
       with:
@@ -107,7 +107,7 @@ runs:
         result-encoding: string
     - name: Select First Commit
       id: first-commit
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         COMMIT: ${{ steps.commits.outputs.result }}
       with:
@@ -118,7 +118,7 @@ runs:
         result-encoding: string
     - name: Select Last Commit
       id: last-commit
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         COMMIT: ${{ steps.commits.outputs.result }}
       with:
@@ -188,7 +188,7 @@ runs:
 
     - name: Comment Integrations
       id: comment-integrations
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
       env:
         HEAD_REF: ${{ steps.first-commit.outputs.result || github.head_ref || github.event.pull_request.head.ref || 'HEAD' }}
         CHANGED_FILES: ${{ steps.generate-comment-data.outputs.changed_files }}


### PR DESCRIPTION
In default mode, zizmor suppressed 30 warnings which were actually quite interesting as they were about broader-than-necessary permissions (or scope), and unpinned GitHub actions. 

By enabling its pedantic mode, it now reports them.

This PR also fixes the initially reported issues.