### PR TITLE
Fix config file yq

### DIFF
--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -42,7 +42,7 @@ runs:
         CONFIG_PATH: ${{ inputs.config_path }}
       run: |
         sudo apt-get install -y yq
-        CONVERSION_PATH=$(yq '.folders.conversion_path' "${CONFIG_PATH}")
+        CONVERSION_PATH=$(yq --raw-output '.folders.conversion_path' "${CONFIG_PATH}")
         echo "conversion_path=${CONVERSION_PATH}" >> $GITHUB_OUTPUT
     - name: Login to GitHub Container Registry
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0

--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -89,7 +89,7 @@ runs:
         CONFIG_PATH: ${{ inputs.config_path }}
       run: |
         sudo apt-get install -y yq
-        GRAFANA_INSTANCE=$(yq '.deployment.grafana_instance' "${CONFIG_PATH}")
+        GRAFANA_INSTANCE=$(yq --raw-output '.deployment.grafana_instance' "${CONFIG_PATH}")
         echo "grafana_instance=${GRAFANA_INSTANCE}" >> $GITHUB_OUTPUT
     - name: Comment Status
       if: success() && github.event_name == 'push'

--- a/actions/integrate/action.yml
+++ b/actions/integrate/action.yml
@@ -50,9 +50,9 @@ runs:
         CONFIG_PATH: ${{ inputs.config_path }}
       run: |
         sudo apt-get install -y yq
-        CONVERSION_PATH=$(yq '.folders.conversion_path' "${CONFIG_PATH}")
+        CONVERSION_PATH=$(yq --raw-output '.folders.conversion_path' "${CONFIG_PATH}")
         echo "conversion_path=${CONVERSION_PATH}" >> $GITHUB_OUTPUT
-        DEPLOYMENT_PATH=$(yq '.folders.deployment_path' "${CONFIG_PATH}")
+        DEPLOYMENT_PATH=$(yq --raw-output '.folders.deployment_path' "${CONFIG_PATH}")
         echo "deployment_path=${DEPLOYMENT_PATH}" >> $GITHUB_OUTPUT
 
     - name: Login to GitHub Container Registry


### PR DESCRIPTION
Use `--raw-output` in `yq` to avoid unnecessary quotation marks in our commands.