### PR TITLE
Clean up orphaned conversion files that have no config

### DIFF
--- a/actions/integrate/integrator.go
+++ b/actions/integrate/integrator.go
@@ -216,52 +216,33 @@ func (i *Integrator) LoadConfig() error {
 	return nil
 }
 
-// cleanupOrphanedFiles removes conversion files that have no matching configuration
-//
-// todo: Make this generic for handling files in both the conversions and deployments path
-func (i *Integrator) cleanupOrphanedFiles() error {
-	// Get all conversion files in the conversion path
-	var conversionFiles []string
-	err := filepath.Walk(i.config.Folders.ConversionPath, func(path string, info os.FileInfo, err error) error {
+// cleanupOrphanedFilesInPath removes orphaned files in the specified path
+func (i *Integrator) cleanupOrphanedFilesInPath(searchPath string, isOrphaned func(string) (bool, error)) error {
+	// Get all JSON files in the path
+	var files []string
+	err := filepath.Walk(searchPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 		if !info.IsDir() && strings.HasSuffix(path, ".json") {
-			conversionFiles = append(conversionFiles, path)
+			files = append(files, path)
 		}
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to walk conversion directory: %w", err)
+		return fmt.Errorf("failed to walk directory %s: %w", searchPath, err)
 	}
 
-	// Check each conversion file for orphaned status
-	for _, file := range conversionFiles {
-		// Read the conversion file to get its conversion name
-		content, err := ReadLocalFile(file)
+	// Check each file for orphaned status
+	for _, file := range files {
+		orphaned, err := isOrphaned(file)
 		if err != nil {
-			fmt.Printf("Warning: Could not read conversion file %s: %v\n", file, err)
+			fmt.Printf("Warning: Could not check file %s: %v\n", file, err)
 			continue
 		}
 
-		var conversionObject ConversionOutput
-		if err := json.Unmarshal([]byte(content), &conversionObject); err != nil {
-			fmt.Printf("Warning: Could not parse conversion file %s: %v\n", file, err)
-			continue
-		}
-
-		// Check if this conversion name has a matching configuration
-		hasMatchingConfig := false
-		for _, conf := range i.config.Conversions {
-			if conf.Name == conversionObject.ConversionName {
-				hasMatchingConfig = true
-				break
-			}
-		}
-
-		// If no matching configuration found, remove the orphaned file
-		if !hasMatchingConfig {
-			fmt.Printf("Removing orphaned conversion file: %s (conversion name: %s)\n", file, conversionObject.ConversionName)
+		if orphaned {
+			fmt.Printf("Removing orphaned file: %s\n", file)
 			if err := os.Remove(file); err != nil {
 				fmt.Printf("Warning: Could not remove orphaned file %s: %v\n", file, err)
 			}
@@ -269,6 +250,50 @@ func (i *Integrator) cleanupOrphanedFiles() error {
 	}
 
 	return nil
+}
+
+// isConversionFileOrphaned checks if a conversion file has no matching configuration
+func (i *Integrator) isConversionFileOrphaned(file string) (bool, error) {
+	content, err := ReadLocalFile(file)
+	if err != nil {
+		return false, err
+	}
+
+	var conversionObject ConversionOutput
+	if err := json.Unmarshal([]byte(content), &conversionObject); err != nil {
+		return false, err
+	}
+
+	// Check if this conversion name has a matching configuration
+	for _, conf := range i.config.Conversions {
+		if conf.Name == conversionObject.ConversionName {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// isDeploymentFileOrphaned checks if a deployment file references a missing conversion file
+func (i *Integrator) isDeploymentFileOrphaned(file string) (bool, error) {
+	content, err := ReadLocalFile(file)
+	if err != nil {
+		return false, err
+	}
+
+	var deploymentRule definitions.ProvisionedAlertRule
+	if err := json.Unmarshal([]byte(content), &deploymentRule); err != nil {
+		return false, err
+	}
+
+	// Check if the referenced conversion file still exists
+	if conversionFile := deploymentRule.Annotations["ConversionFile"]; conversionFile != "" {
+		if _, err := os.Stat(conversionFile); os.IsNotExist(err) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (i *Integrator) Run() error {
@@ -386,9 +411,14 @@ func (i *Integrator) Run() error {
 		}
 	}
 
-	// Clean up orphaned files that have no matching configuration
-	if err := i.cleanupOrphanedFiles(); err != nil {
-		fmt.Printf("Warning: Error during orphaned file cleanup: %v\n", err)
+	// Clean up orphaned conversion files
+	if err := i.cleanupOrphanedFilesInPath(i.config.Folders.ConversionPath, i.isConversionFileOrphaned); err != nil {
+		fmt.Printf("Warning: Error during orphaned conversion file cleanup: %v\n", err)
+	}
+
+	// Clean up orphaned deployment files
+	if err := i.cleanupOrphanedFilesInPath(i.config.Folders.DeploymentPath, i.isDeploymentFileOrphaned); err != nil {
+		fmt.Printf("Warning: Error during orphaned deployment file cleanup: %v\n", err)
 	}
 
 	rulesIntegrated := strings.Join(i.addedFiles, " ")


### PR DESCRIPTION
Closes https://github.com/grafana/sigma-rule-deployment/issues/85

This change automatically checks for orphaned conversion and deployment files each time the integrator runs and cleans up any of these files that no longer have a configuration.

The integrator runs each time the GitHub Action is executed and is responsible for extracting the conversion output files into alert rules. At the end of each `Run()`, the integrator now also iterates through conversion and deployment files and removes any that no longer have a configuration.

### Conversion files
Conversion files are determined to be orphaned if they do not have any configuration. When a configuration does exist, the converter takes its `name` field and uses that for the conversion file’s `conversion_name` field. Therefore, if the conversion file we are looking at does not have a matching `name` in the config file, we know we can remove it.

### Deployment files
Deployment files are mapped 1:1 back to conversion files via the `ConversionFile` annotation (https://github.com/grafana/sigma-rule-deployment/pull/123). If that conversion file does not exist (as it was removed in the previous step), we now know we can remove the deployment file that belongs to it.