### PR TITLE
Use the zizmor GitHub action

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: Security Scan with Zizmor
+name: Zizmor Security Scan
 
 on:
   push:
@@ -7,27 +7,22 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
 
 permissions: {}
 
 jobs:
   security-scan:
-    name: "Run Zizmor Security Scan"
+    name: Run Zizmor Security Scan
     runs-on: ubuntu-latest
     permissions:
+      checks: write # Required for reporting test results and creating check runs
       contents: read
-      checks: write
+      actions: read # Needed for private repos
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
-      - name: Install zizmor
-        run: |
-          pip install zizmor
-
       - name: Run zizmor on all files
-        run: |
-          zizmor -p .
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0


### PR DESCRIPTION
Right now our zizmor action uses an unpinned version via `pip install zizmor`. Using an unpinned version means that if new errors are introduced between versions, CI can start failing on changes that are unrelated (such as https://github.com/grafana/sigma-rule-deployment/actions/runs/17741425095/job/50416412230).

This change updates `zizmor.yml` Github workflow to use the zizmor Github Action which is pinned. When this version is changed in the future, manually or through dependabot, we should pick up breaking changes in the PR and can update the repo accordingly before merging.