### PR TITLE
Add User-Agent to deployer and integrator

### DIFF
--- a/actions/deploy/deployer.go
+++ b/actions/deploy/deployer.go
@@ -431,6 +431,7 @@ func (d *Deployer) createAlert(ctx context.Context, content string, updateIfExis
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.config.saToken))
+	req.Header.Add("User-Agent", "sigma-rule-deployment/deployer")
 
 	res, err := d.client.Do(req)
 	if err != nil {
@@ -517,6 +518,7 @@ func (d *Deployer) updateAlert(ctx context.Context, content string, createIfNotF
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.config.saToken))
+	req.Header.Add("User-Agent", "sigma-rule-deployment/deployer")
 
 	res, err := d.client.Do(req)
 	if err != nil {

--- a/actions/integrate/dsquery.go
+++ b/actions/integrate/dsquery.go
@@ -210,6 +210,7 @@ func (h *HTTPDatasourceQuery) ExecuteQuery(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+	req.Header.Set("User-Agent", "sigma-rule-deployment/integrator")
 
 	client := &http.Client{
 		Timeout: timeout,
@@ -289,6 +290,7 @@ func (h *HTTPDatasourceQuery) getDatasourceRequest(
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "sigma-rule-deployment/integrator")
 
 	client := &http.Client{
 		Timeout: timeout,


### PR DESCRIPTION
Closes #148

Add `User-Agent` headers to all HTTP requests made to Grafana APIs to enable better usage tracking and debugging.

The headers have distinct values to differentiate between query testing (`sigma-rule-deployment/integrator`) and rule deployment (`sigma-rule-deployment/deployer`) operations in the API logs. The converter does not ever call the Grafana API.