### PR TITLE
Ensure non-nil response from query testing errors

### DIFF
--- a/actions/integrate/integrator.go
+++ b/actions/integrate/integrator.go
@@ -821,7 +821,16 @@ func (i *Integrator) TestQueries(queries map[string]string, config, defaultConf 
 			timeoutDuration,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error testing query %s: %v", query, err)
+			return []QueryTestResult{
+				{
+					Datasource: datasource,
+					Link:       "",
+					Stats: Stats{
+						Fields: make(map[string]string),
+						Errors: []string{err.Error()},
+					},
+				},
+			}, fmt.Errorf("error testing query %s: %v", query, err)
 		}
 
 		// Generate explore link based on datasource type


### PR DESCRIPTION
Attempt to fix issue #154 where errors during integration query testing will cause it produce a nil response, causing the subsequent processing stages in the action to fail. Instead, we return an empty test result with the specific error that occurred.