### PR TITLE
Fix empty lines appearing in queries output

### DIFF
--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -319,7 +319,7 @@ def convert_rules(
                 queries = [
                     line
                     for line in result.stdout.splitlines()
-                    if "Parsing Sigma rules" not in line
+                    if "Parsing Sigma rules" not in line and len(line.strip()) != 0
                 ]
 
                 if not queries:


### PR DESCRIPTION
Sigma produces queries with an additional empty line between them - the converter wasn't excluding them. Fixes #166.