### PR TITLE
Update field used for calculating changes

### DIFF
--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -74,7 +74,7 @@ runs:
               base_commit = remote_commit.parents[0].sha;
               first_commit = remote_commit.sha;
             }
-            if (remote_commit.commit.committer.name === process.env.ACTIONS_USERNAME) {
+            if (remote_commit.commit.author.name === process.env.ACTIONS_USERNAME) {
               commit = remote_commit.sha;
               last_commit = remote_commit.sha;
             }
@@ -228,7 +228,7 @@ runs:
                 }
               }
           }`;
-          
+
           const minimizeCommentMutation = `mutation MinimizeComment($subjectId: ID!) {
             minimizeComment(input: {
               subjectId: $subjectId,
@@ -257,7 +257,7 @@ runs:
             name: context.repo.repo,
             number: parseInt(process.env.PULL_REQUEST_NUMBER, 10)
           });
-          
+
           for (const comment of comments?.repository?.pullRequest?.comments?.nodes ?? []) {
             if (!comment.isMinimized && comment.bodyText.startsWith("Sigma Rule Conversions")) {
               await github.graphql(minimizeCommentMutation, {

--- a/actions/integrate/action.yml
+++ b/actions/integrate/action.yml
@@ -106,7 +106,7 @@ runs:
               base_commit = remote_commit.parents[0].sha;
               first_commit = remote_commit.sha;
             }
-            if (remote_commit.commit.committer.name === process.env.ACTIONS_USERNAME) {
+            if (remote_commit.commit.author.name === process.env.ACTIONS_USERNAME) {
               commit = remote_commit.sha;
               last_commit = remote_commit.sha;
             }
@@ -246,7 +246,7 @@ runs:
 
           ${resultTable}
           `;
-          
+
           const oldCommentQuery = `query GetPRComments($owner: String!, $name: String!, $number: Int!) {
               repository(owner: $owner, name: $name) {
                 id
@@ -265,7 +265,7 @@ runs:
                 }
               }
           }`;
-          
+
           const minimizeCommentMutation = `mutation MinimizeComment($subjectId: ID!) {
             minimizeComment(input: {
               subjectId: $subjectId,
@@ -288,13 +288,13 @@ runs:
               }
             }
           }`
-          
+
           const comments = await github.graphql(oldCommentQuery, {
             owner: context.repo.owner,
             name: context.repo.repo,
             number: parseInt(process.env.PULL_REQUEST_NUMBER, 10)
           });
-          
+
           for (const comment of comments?.repository?.pullRequest?.comments?.nodes ?? []) {
             if (!comment.isMinimized && comment.bodyText.startsWith("Sigma Rule Integrations")) {
               await github.graphql(minimizeCommentMutation, {


### PR DESCRIPTION
This updates which commits are selected to use the `commit author` instead of the `commit committer` which is updated during a rebase.

This is based off of a commit in another repository that looks like the following:

```json
"commit": {
    "author": {
      "name": "sigma-rule-deployment-app[bot]",
      "email": "234162409+sigma-rule-deployment-app[bot]@users.noreply.github.com",
      "date": "2025-10-17T12:06:39Z"
    },
    "committer": {
      "name": "James Crocker",
      "email": "87319125+jamesc-grafana@users.noreply.github.com",
      "date": "2025-10-22T14:14:26Z"
    },
    "message": "Sigma Rules Deployment",
```