### PR TITLE
Update README with instructions for releases

### DIFF
--- a/.github/workflows/convert-integrate.yml
+++ b/.github/workflows/convert-integrate.yml
@@ -116,7 +116,7 @@ jobs:
           fetch-depth: 0
 
       - name: Convert Sigma rules
-        uses: ./actions/convert
+        uses: grafana/sigma-rule-deployment/actions/convert@v0.0.2
         with:
           config_path: ${{ inputs.config_path }}
           plugin_packages: ${{ inputs.plugin_packages }}
@@ -127,7 +127,7 @@ jobs:
           changed_files_from_base: ${{ inputs.changed_files_from_base }}
 
       - name: Integrate queries into alert rules
-        uses: ./actions/integrate
+        uses: grafana/sigma-rule-deployment/actions/integrate@v0.0.2
         with:
           config_path: ${{ inputs.config_path }}
           grafana_sa_token: ${{ secrets.grafana_sa_token || env.GRAFANA_SA_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Deploy alert rules to Grafana
         id: deploy
-        uses: ./actions/deploy
+        uses: grafana/sigma-rule-deployment/actions/deploy@v0.0.2
         with:
           config_path: ${{ inputs.config_path }}
           fresh_deploy: ${{ inputs.fresh_deploy }}

--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ Sigma Rule Deployment automates this workflow: it provides GitHub Actions to con
 To release new versions of sigma-rule-deployment, we use Git tags to denote an officially released version, and automation to push the appropriately tagged Docker image. When the main branch is in state that is ready to release, the process is as follows:
 
 1. Determine the correct version number using the [Semantic Versioning](https://semver.org/) methodology. All version numbers should be in the format `\d+\.\d+\.\d+(-[0-9A-Za-z-]+)?`
-2. Checkout `main` and create a signed tag for the release, named the version number prefixed with a v, e.g., `git tag --sign --message="Release vX.X.X" vX.X.X`
-3. Push the tag to GitHub, e.g., `git push --tags`
-4. Create a release in GitHub against the appropriate tag. If the version number starts with `v0`, or ends with `-alpha/beta/rcX` etc., remember to mark it as a pre-release
-5. Validate that the "Build Consolidated Image" action, which pushes the tagged image to the GitHub Container Repository (GHCR), has completed successfully for the Release action
+2. Create a PR to update **all** the version tags used in the reusable workflows [convert-integrate.yml](.github/workflows/convert-integrate.yml) and [deploy.yml](.github/workflows/deploy.yml) to the new version, and merge it into `main` once it is approved, e.g.:
+```
+        uses: grafana/sigma-rule-deployment/actions/convert@vX.X.X
+```
+3. Checkout `main` and create a signed tag for the release, named the version number prefixed with a v, e.g., `git tag --sign --message="Release vX.X.X" vX.X.X`
+4. Push the tag to GitHub, e.g., `git push --tags`
+5. Create a release in GitHub against the appropriate tag. If the version number starts with `v0`, or ends with `-alpha/beta/rcX` etc., remember to mark it as a pre-release
+6. Validate that the "Build Consolidated Image" action, which pushes the tagged image to the GitHub Container Repository (GHCR), has completed successfully for the Release action


### PR DESCRIPTION
We should release our project consistently - this commit adds instructions on how we should do so (using signed tags and validating the release was successful). It also updates the version hashes for the reusable workflows to match the latest released version.