### PR TITLE
Update the reusable workflow to allow empty commits from SRD

### DIFF
--- a/.github/workflows/convert-integrate.yml
+++ b/.github/workflows/convert-integrate.yml
@@ -142,5 +142,6 @@ jobs:
         with:
           commit_message: "Sigma Rules Deployment"
           branch: ${{ github.event_name == 'issue_comment' && steps.get-pr-branch.outputs.result || github.head_ref }}
+          commit_options: '--allow-empty'
           skip_checkout: true
           skip_fetch: true


### PR DESCRIPTION
Our automation tracks when SRD has run by looking back at its commits. However, if SRD doesn't need to make any changes, it doesn't produce a commit by default, and hence the fact it had run was being missed.

This PR changes that default to allow SRD to create empty commits, which have no changes, but maintain our ability to see it ran successfully.