### PR TITLE
Use Provided YQ

### DIFF
--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -41,7 +41,7 @@ runs:
       env:
         CONFIG_PATH: ${{ inputs.config_path }}
       run: |
-        CONVERSION_PATH=$(yq --raw-output '.folders.conversion_path' "${CONFIG_PATH}")
+        CONVERSION_PATH=$(yq -r '.folders.conversion_path' "${CONFIG_PATH}")
         echo "conversion_path=${CONVERSION_PATH}" >> $GITHUB_OUTPUT
     - name: Login to GitHub Container Registry
       uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/actions/integrate/action.yml
+++ b/actions/integrate/action.yml
@@ -53,9 +53,9 @@ runs:
       env:
         CONFIG_PATH: ${{ inputs.config_path }}
       run: |
-        CONVERSION_PATH=$(yq --raw-output '.folders.conversion_path' "${CONFIG_PATH}")
+        CONVERSION_PATH=$(yq -r '.folders.conversion_path' "${CONFIG_PATH}")
         echo "conversion_path=${CONVERSION_PATH}" >> $GITHUB_OUTPUT
-        DEPLOYMENT_PATH=$(yq --raw-output '.folders.deployment_path' "${CONFIG_PATH}")
+        DEPLOYMENT_PATH=$(yq -r '.folders.deployment_path' "${CONFIG_PATH}")
         echo "deployment_path=${DEPLOYMENT_PATH}" >> $GITHUB_OUTPUT
 
     - name: Login to GitHub Container Registry


### PR DESCRIPTION
`ubuntu-latest` (24.04) is supposed to provide the `yq` binary, which would mean we don't need to install it. This PR experiments with using the built in version