### PR TITLE
use the builtin yq for deployment too

### DIFF
--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -105,8 +105,7 @@ runs:
       env:
         CONFIG_PATH: ${{ inputs.config_path }}
       run: |
-        sudo apt-get install -y yq
-        GRAFANA_INSTANCE=$(yq --raw-output '.deployment.grafana_instance' "${CONFIG_PATH}")
+        GRAFANA_INSTANCE=$(yq -r '.deployment.grafana_instance' "${CONFIG_PATH}")
         echo "grafana_instance=${GRAFANA_INSTANCE}" >> $GITHUB_OUTPUT
     - name: Comment Status
       if: success() && github.event_name == 'push'


### PR DESCRIPTION
Uses the builtin version of `yq` to get the required parameters rather than installing an updated version