### PR TITLE
Use a PR to update main integration test branch

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -162,6 +162,8 @@ jobs:
           ACTION_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git fetch
+          git checkout main
+          git pull
 
           STATUS=0
           git rev-parse --verify "integration-test-main-update-${GITHUB_PR_NUMBER}" 2>/dev/null || STATUS=$?
@@ -185,6 +187,7 @@ jobs:
 
           git push origin "integration-test-main-update-${GITHUB_PR_NUMBER}" --force
           gh pr create --title "Integration Test Main Update ${GITHUB_PR_NUMBER}" --body "This PR updates the main branch to the relevant hash for grafana/sigma-rule-deployment#${GITHUB_PR_NUMBER}" --head "integration-test-main-update-${GITHUB_PR_NUMBER}" --base main
+          sleep 10 # wait for the PR checks to start...
 
           # wait for the required PR checks to complete
           if gh pr checks "integration-test-main-update-${GITHUB_PR_NUMBER}" --watch; then


### PR DESCRIPTION
The comment test integration test is currently failing due to the mandatory zizmor check. This PR changes the approach used from pushing to the main branch to opening a PR, awaiting the mandatory checks, and merging the PR.

This test feels to me likely to be a little flaky - there's a few hardcoded constants like the delays that are necessary for the tests to work at all. If GitHub is having a sad day, it might well break :grimacing: 