### PR TITLE
Set the reviewer for integration test PRs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -203,8 +203,6 @@ jobs:
 
           # wait for the required PR checks to complete
           if gh pr checks "integration-test-main-update-${GITHUB_PR_NUMBER}" --watch; then
-            gh pr edit "integration-test-main-update-${GITHUB_PR_NUMBER}" \
-            --remove-reviewer "grafana/security-operations"
             gh pr ready "integration-test-main-update-${GITHUB_PR_NUMBER}"
             gh pr merge "integration-test-main-update-${GITHUB_PR_NUMBER}" --auto --squash
             sleep 5 # wait for the merge to complete


### PR DESCRIPTION
Since we added the CODEOWNERS to the integration-test repo, we've started getting even more notifications about PRs (multiple emails per PR). This simply isn't sustainable, so this PR reduces the volume of those emails by marking the integration test PR as draft (and then closing it) and only marking the main merge PR as ready at the last moment, to reduce the number of notifications generated.