### PR TITLE
Disable revive check for shared package

### DIFF
--- a/shared/config.go
+++ b/shared/config.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package shared
 
 import (

--- a/shared/grafanahttp.go
+++ b/shared/grafanahttp.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package shared
 
 import (

--- a/shared/util.go
+++ b/shared/util.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package shared
 
 import (


### PR DESCRIPTION
Our `golangci-lint` check was failing as revive started picking up the package name `shared` as being problematic. I don't think it is, so I have disabled this check with comments.