### PR TITLE
Make Dockerfile more flexible to version changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ COPY --from=builder /build/sigma-deployer /usr/local/bin/sigma-deployer
 COPY ./actions/convert ./actions/convert
 
 WORKDIR /app/actions/convert
-RUN apk add --no-cache bash=5.2.37-r0 && \
-    python -m pip install --no-cache-dir --upgrade pip==25.0.1 && \
-    pip install --no-cache-dir uv==0.6.13
+RUN apk add --no-cache bash~=5.2 && \
+    python -m pip install --no-cache-dir --upgrade pip~=25.3.0 && \
+    pip install --no-cache-dir uv~=0.9.0
 
 WORKDIR /app
 


### PR DESCRIPTION
Previously, we hard-coded versions of `bash`, `pip`, and `uv` in the Dockerfile. This has lead to issues when automatically updating alpine images. However, our code had minimal dependencies on these versions.

This changes the updates to require a compatible version for these packages be installed, hopefully increasing our flexibility around updates.