### PR TITLE
Config v2 migration: Implement v2 config format in convert action

### DIFF
--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -150,6 +150,13 @@ def convert_rules(
         print("No changed, deleted or manual files identified, but all_rules is false")
         exit(0)
 
+    # Validate config version
+    config_version = config.get("version")
+    if config_version != 2:
+        raise ValueError(
+            f"Unsupported config version {config_version!r}: only version 2 is supported"
+        )
+
     # Get the conversion path from the config
     conversion_path = "conversions"  # Default conversion path if none is set
     if folders := config.get("folders"):
@@ -163,25 +170,29 @@ def convert_rules(
     # Create the output directory if it doesn't exist
     conversions_output_dir.mkdir(parents=True, exist_ok=True)
 
+    defaults = dict((config.get("defaults") or {}).get("conversion") or {})
+    raw_conversions = config.get("configurations") or []
+    conversions = []
+    for entry in raw_conversions:
+        item = dict(entry.get("conversion") or {})
+        item["name"] = entry.get("name")
+        conversions.append(item)
+    verbose = defaults.pop("verbose", False)
 
-    # Get top-level default values
-    default_target = config.get("conversion_defaults.target", "loki")
-    default_format = config.get("conversion_defaults.format", "default")
-    default_skip_unsupported = config.get("conversion_defaults.skip_unsupported", True)
-    default_fail_unsupported = config.get("conversion_defaults.fail_unsupported", False)
-    default_encoding = config.get("conversion_defaults.encoding", "utf-8")
-    default_pipeline_check = config.get("conversion_defaults.pipeline_check", True)
-    default_file_pattern = config.get("conversion_defaults.file_pattern", "*.yml")
-    default_correlation_method = config.get(
-        "conversion_defaults.correlation_method", []
-    )
-    default_filters = config.get("conversion_defaults.filters", [])
-    default_backend_options = config.get("conversion_defaults.backend_options", {})
-    default_without_pipeline = config.get("conversion_defaults.without_pipeline", False)
-    default_pipelines = config.get("conversion_defaults.pipelines", [])
-    default_json_indent = config.get("conversion_defaults.json_indent", 0)
-    default_required_rule_fields = config.get("conversion_defaults.required_rule_fields", [])
-    verbose = config.get("verbose", False)
+    default_target = defaults.get("target", "loki")
+    default_format = defaults.get("format", "default")
+    default_skip_unsupported = defaults.get("skip_unsupported", True)
+    default_fail_unsupported = defaults.get("fail_unsupported", False)
+    default_encoding = defaults.get("encoding", "utf-8")
+    default_pipeline_check = defaults.get("pipeline_check", True)
+    default_file_pattern = defaults.get("file_pattern", "*.yml")
+    default_correlation_method = defaults.get("correlation_method", [])
+    default_filters = defaults.get("filters", [])
+    default_backend_options = defaults.get("backend_options", {})
+    default_without_pipeline = defaults.get("without_pipeline", False)
+    default_pipelines = defaults.get("pipelines", [])
+    default_json_indent = defaults.get("json_indent", 0)
+    default_required_rule_fields = defaults.get("required_rule_fields", [])
 
     # Backfill the manual flag onto conversion files a human modified since the last
     # automation commit. Doing this before the conversion loop means the freshly-added
@@ -215,7 +226,7 @@ def convert_rules(
     conversion_errors = []
 
     # Convert Sigma rules to the target format per each conversion object in the config
-    for conversion in config.get("conversions", []):
+    for conversion in conversions:
         # If the conversion name is not unique, we'll overwrite the output file,
         # which might not be the desired behavior for the user.
         name = conversion.get("name", None)
@@ -274,7 +285,7 @@ def convert_rules(
                 raise ValueError("Invalid input file type")
 
         # Apply file_pattern filtering to exclude files that don't match the pattern
-        file_pattern = conversion.get("file_pattern", default_file_pattern)
+        file_pattern = conversion.get("file_pattern") or default_file_pattern
         filtered_files = [f for f in input_files if fnmatch.fnmatch(f, file_pattern)]
 
         # Skip conversion if no files match the pattern
@@ -289,8 +300,8 @@ def convert_rules(
         if config_file_changed and previous_config is not None:
             prev_conversion = next(
                 (
-                    c
-                    for c in previous_config.get("conversions", [])
+                    c.get("conversion", {})
+                    for c in previous_config.get("configurations", [])
                     if c.get("name") == name
                 ),
                 None,
@@ -312,17 +323,17 @@ def convert_rules(
             print("Converting all discovered rules")
 
         # Verify that all pipeline files are relative to the repository root (GITHUB_WORKSPACE)
-        for pipeline in conversion.get("pipelines", default_pipelines):
+        for pipeline in (conversion.get("pipelines") or default_pipelines):
             if Path(pipeline).is_absolute():
                 raise ValueError(
                     "Pipeline file path must be relative to the project root"
                 )
 
-        encoding = conversion.get("encoding", default_encoding)
+        encoding = conversion.get("encoding") or default_encoding
 
         pipelines = []
         any_pipeline_changed = False
-        for pipeline in conversion.get("pipelines", default_pipelines):
+        for pipeline in (conversion.get("pipelines") or default_pipelines):
             if is_path(pipeline, file_pattern):
                 pipeline_path = path_prefix / Path(pipeline)
                 pipelines.append(f"--pipeline={pipeline_path}")
@@ -375,7 +386,7 @@ def convert_rules(
                         else []
                     )
                 ),
-                *[f"--filter={f}" for f in conversion.get("filters", default_filters)],
+                *[f"--filter={f}" for f in (conversion.get("filters") or default_filters)],
                 "--file-pattern",
                 file_pattern,
                 "--output",
@@ -384,8 +395,8 @@ def convert_rules(
                 encoding,
                 *[
                     f"--backend-option={k}={v}"
-                    for k, v in conversion.get(
-                        "backend_options", default_backend_options
+                    for k, v in (
+                        conversion.get("backend_options") or default_backend_options
                     ).items()
                 ],
                 *(
@@ -455,7 +466,7 @@ def convert_rules(
                     continue
 
                 # Filter the rules to only include the required fields, if empty, return the full rule dictionaries
-                required_rule_fields = conversion.get("required_rule_fields", default_required_rule_fields)
+                required_rule_fields = conversion.get("required_rule_fields") or default_required_rule_fields
 
                 # Create the output data structure
                 output_data = {
@@ -573,9 +584,8 @@ def filter_rule_fields(rule_dicts: list[dict[str, Any]], desired_fields: list[st
     """
     if not desired_fields:
         return rule_dicts
-    else:
-        # Ensure desired_fields contains at least the id and title fields
-        necessary_fields = set(["id", "title"] + desired_fields)
+    # Ensure desired_fields contains at least the id and title fields
+    necessary_fields = set(["id", "title"] + desired_fields)
 
     return [dict((field, rule_dict[field]) for field in necessary_fields if field in rule_dict) for rule_dict in rule_dicts]
 
@@ -590,22 +600,26 @@ def get_config_changes(previous_config: Dynaconf, current_config: Dynaconf) -> t
         tuple[bool, list[str]]: A tuple containing a boolean indicating if a global config setting changed and a list of conversion names whose config changed.
     """
     global_config_changed = False
-    # Check if any global config settings changed (except for conversions)
-    for key in ["conversion_defaults", "folders", "verbose"]:
+    # Check if any global config settings changed (except for per-configuration conversion blocks)
+    for key in ["folders"]:
         if current_config.get(key) != previous_config.get(key):
             global_config_changed = True
             break
+    if (current_config.get("defaults") or {}).get("conversion") != (
+        previous_config.get("defaults") or {}
+    ).get("conversion"):
+        global_config_changed = True
 
     changed_conversions = []
-    for conversion in current_config.get("conversions", []):
-        name = conversion.get("name", None)
+    for entry in current_config.get("configurations", []):
+        name = entry.get("name", None)
         if not name:
             continue
-        prev_conversion = next(
-            (c for c in previous_config.get("conversions", []) if c.get("name") == name),
+        prev_entry = next(
+            (c for c in previous_config.get("configurations", []) if c.get("name") == name),
             None,
         )
-        if prev_conversion is None or conversion != prev_conversion:
+        if prev_entry is None or entry.get("conversion") != prev_entry.get("conversion"):
             changed_conversions.append(name)
     return global_config_changed, changed_conversions
 

--- a/actions/convert/test_convert.py
+++ b/actions/convert/test_convert.py
@@ -13,21 +13,26 @@ from convert.convert import convert_rules, is_path, is_safe_path, load_rules, fi
 
 @pytest.fixture
 def mock_config():
-    """Mock configuration object."""
+    """Mock v2 configuration object."""
     return DynaconfDict(
         {
-            "conversion_defaults": {
-                "target": "loki",
-                "format": "default",
-                "skip_unsupported": "true",
-                "file_pattern": "*.yml",
-            },
-            "conversions": [
-                {
-                    "name": "test_conversion",
-                    "input": ["rules/*.yml"],
+            "version": 2,
+            "defaults": {
+                "conversion": {
                     "target": "loki",
                     "format": "default",
+                    "skip_unsupported": "true",
+                    "file_pattern": "*.yml",
+                },
+            },
+            "configurations": [
+                {
+                    "name": "test_conversion",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 }
             ],
         }
@@ -36,22 +41,27 @@ def mock_config():
 
 @pytest.fixture
 def mock_config_with_correlation_rule():
-    """Mock configuration object with a correlation rule."""
+    """Mock v2 configuration object with a correlation rule."""
     return DynaconfDict(
         {
-            "conversion_defaults": {
-                "target": "loki",
-                "format": "default",
-                "skip_unsupported": "true",
-                "file_pattern": "*.yml",
-                "encoding": "utf-8",
-            },
-            "conversions": [
-                {
-                    "name": "test_conversion_with_correlation_rule",
-                    "input": ["rules/correlation.yml"],
+            "version": 2,
+            "defaults": {
+                "conversion": {
                     "target": "loki",
                     "format": "default",
+                    "skip_unsupported": "true",
+                    "file_pattern": "*.yml",
+                    "encoding": "utf-8",
+                },
+            },
+            "configurations": [
+                {
+                    "name": "test_conversion_with_correlation_rule",
+                    "conversion": {
+                        "input": ["rules/correlation.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 }
             ],
         }
@@ -63,26 +73,33 @@ def mock_config_two_groups():
     """Mock configuration object with two independent conversion groups."""
     return DynaconfDict(
         {
-            "conversion_defaults": {
-                "target": "loki",
-                "format": "default",
-                "skip_unsupported": "true",
-                "file_pattern": "*.yml",
-            },
-            "conversions": [
-                {
-                    "name": "group_a",
-                    "input": ["rules/*.yml"],
+            "version": 2,
+            "defaults": {
+                "conversion": {
                     "target": "loki",
                     "format": "default",
+                    "skip_unsupported": "true",
+                    "file_pattern": "*.yml",
+                },
+            },
+            "configurations": [
+                {
+                    "name": "group_a",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 },
                 {
                     "name": "group_b",
-                    "input": ["rules/*.yml"],
-                    # A different but genuinely installed backend, so a real
-                    # sigma-cli invocation for this group actually succeeds.
-                    "target": "text_query_test",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        # A different but genuinely installed backend, so a real
+                        # sigma-cli invocation for this group actually succeeds.
+                        "target": "text_query_test",
+                        "format": "default",
+                    },
                 },
             ],
         }
@@ -130,6 +147,14 @@ def test_convert_rules_missing_path_prefix():
         convert_rules(config=DynaconfDict(), path_prefix="")
 
 
+@pytest.mark.parametrize("version", [None, 0, 1, 3, "2"])
+def test_convert_rules_unsupported_version(temp_workspace, version):
+    """Test that an error is raised when the config version is not 2."""
+    config = DynaconfDict({"version": version} if version is not None else {})
+    with pytest.raises(ValueError, match="only version 2 is supported"):
+        convert_rules(config=config, path_prefix=temp_workspace, all_rules=True)
+
+
 def test_convert_rules_invalid_output_dir(temp_workspace, mock_config):
     """Test that an error is raised when output directory is outside the project root."""
     mock_config["folders"] = {"conversion_path": "../outside"}
@@ -142,9 +167,9 @@ def test_convert_rules_invalid_output_dir(temp_workspace, mock_config):
 
 
 def test_convert_rules_missing_conversion_name():
-    """Test that an error is raised when conversion name is missing."""
+    """Test that an error is raised when a configuration item has no name."""
     invalid_config = DynaconfDict(
-        {"conversions": [{"input": ["rules/*.yml"], "target": "loki"}]}
+        {"version": 2, "configurations": [{"conversion": {"input": ["rules/*.yml"]}}]}
     )
     with pytest.raises(
         ValueError,
@@ -160,9 +185,10 @@ def test_convert_rules_absolute_input_path():
     """Test that an error is raised when input file pattern is absolute."""
     invalid_config = DynaconfDict(
         {
-            "conversions": [
-                {"name": "test", "input": ["/absolute/path/*.yml"], "target": "loki"}
-            ]
+            "version": 2,
+            "configurations": [
+                {"name": "test", "conversion": {"input": ["/absolute/path/*.yml"]}}
+            ],
         }
     )
     with pytest.raises(ValueError, match="must be relative"):
@@ -212,30 +238,10 @@ def test_convert_rules_successful_conversion_all(temp_workspace, mock_config):
 
     output_file = temp_workspace / "conversions" / "test_conversion_test.json"
     assert output_file.exists()
-    assert output_file.read_text() == json.dumps(
-        {
-            "conversion_name": "test_conversion",
-            "input_file": "rules/test.yml",
-            "output_file": "conversions/test_conversion_test.json",
-            "queries": [
-                '{job=~".+"} | logfmt | userIdentity_type=~`(?i)^Root$` and eventType!~`(?i)^AwsServiceEvent$`'
-            ],
-            "rules": [
-                {
-                    "description": "Detects AWS root account usage",
-                    "detection": {
-                        "condition": "selection and not filter",
-                        "filter": {"eventType": "AwsServiceEvent"},
-                        "selection": {"userIdentity.type": "Root"},
-                    },
-                    "falsepositives": ["AWS Tasks That Require Root User Credentials"],
-                    "level": "medium",
-                    "logsource": {"product": "aws", "service": "cloudtrail"},
-                    "title": "AWS Root Credentials",                    
-                }
-            ],
-        }
-    ).decode("utf-8", "replace")
+    data = json.loads(output_file.read_bytes())
+    assert data["conversion_name"] == "test_conversion"
+    assert len(data["queries"]) == 1
+    assert len(data["rules"]) == 1
 
 
 def test_convert_rules_successful_conversion_changed_files(temp_workspace, mock_config):
@@ -555,6 +561,41 @@ def test_conversion_error_does_not_stop_later_conversions(
     assert len(written) == 1, "the rule that converted should still be written"
 
 
+def test_convert_rules_required_rule_fields_per_conversion(temp_workspace):
+    """Test that required_rule_fields is respected per conversion, overriding the default."""
+    config = DynaconfDict(
+        {
+            "version": 2,
+            "defaults": {
+                "conversion": {
+                    "target": "loki",
+                    "format": "default",
+                    "skip_unsupported": "true",
+                    "file_pattern": "*.yml",
+                    "required_rule_fields": ["title", "level", "description"],
+                },
+            },
+            "configurations": [
+                {
+                    "name": "test_conversion",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "required_rule_fields": ["title"],
+                    },
+                }
+            ],
+        }
+    )
+    convert_rules(config=config, path_prefix=temp_workspace, all_rules=True)
+
+    output_file = temp_workspace / "conversions" / "test_conversion_test.json"
+    assert output_file.exists()
+    data = json.loads(output_file.read_bytes())
+    assert len(data["rules"]) == 1
+    # Only "title" should be present — the per-conversion override takes precedence over the default
+    assert list(data["rules"][0].keys()) == ["title"]
+
+
 def test_load_rule_valid_yaml():
     """Test loading a valid YAML rule file."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
@@ -640,8 +681,8 @@ def test_load_rule_empty_file():
         # Test default values only
         (
             {
-                "conversion_defaults": {},
-                "conversions": [{"name": "test_default", "input": ["test.yml"]}],
+                "defaults": {"conversion": {}},
+                "configurations": [{"name": "test_default", "conversion": {"input": ["test.yml"]}}],
             },
             [
                 "--target",
@@ -663,9 +704,9 @@ def test_load_rule_empty_file():
         # Test overriding target
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
-                    {"name": "test_target", "input": ["test.yml"], "target": "splunk"}
+                "defaults": {"conversion": {}},
+                "configurations": [
+                    {"name": "test_target", "conversion": {"input": ["test.yml"], "target": "splunk"}}
                 ],
             },
             [
@@ -688,9 +729,9 @@ def test_load_rule_empty_file():
         # Test overriding format
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
-                    {"name": "test_format", "input": ["test.yml"], "format": "custom"}
+                "defaults": {"conversion": {}},
+                "configurations": [
+                    {"name": "test_format", "conversion": {"input": ["test.yml"], "format": "custom"}}
                 ],
             },
             [
@@ -713,12 +754,14 @@ def test_load_rule_empty_file():
         # Test setting pipelines
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
+                "defaults": {"conversion": {}},
+                "configurations": [
                     {
                         "name": "test_pipelines",
-                        "input": ["test.yml"],
-                        "pipelines": ["pipeline1.yml", "pipeline2.yml"],
+                        "conversion": {
+                            "input": ["test.yml"],
+                            "pipelines": ["pipeline1.yml", "pipeline2.yml"],
+                        },
                     }
                 ],
             },
@@ -744,12 +787,11 @@ def test_load_rule_empty_file():
         # Test setting correlation method
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
+                "defaults": {"conversion": {}},
+                "configurations": [
                     {
                         "name": "test_correlation",
-                        "input": ["test.yml"],
-                        "correlation_method": "default",
+                        "conversion": {"input": ["test.yml"], "correlation_method": "default"},
                     }
                 ],
             },
@@ -775,12 +817,14 @@ def test_load_rule_empty_file():
         # Test setting filters
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
+                "defaults": {"conversion": {}},
+                "configurations": [
                     {
                         "name": "test_filters",
-                        "input": ["test.yml"],
-                        "filters": ["filter1", "filter2"],
+                        "conversion": {
+                            "input": ["test.yml"],
+                            "filters": ["filter1", "filter2"],
+                        },
                     }
                 ],
             },
@@ -806,12 +850,14 @@ def test_load_rule_empty_file():
         # Test setting backend options
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
+                "defaults": {"conversion": {}},
+                "configurations": [
                     {
                         "name": "test_backend",
-                        "input": ["test.yml"],
-                        "backend_options": {"option1": "value1", "option2": "value2"},
+                        "conversion": {
+                            "input": ["test.yml"],
+                            "backend_options": {"option1": "value1", "option2": "value2"},
+                        },
                     }
                 ],
             },
@@ -837,12 +883,11 @@ def test_load_rule_empty_file():
         # Test without pipeline
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
+                "defaults": {"conversion": {}},
+                "configurations": [
                     {
                         "name": "test_without_pipeline",
-                        "input": ["test.yml"],
-                        "without_pipeline": True,
+                        "conversion": {"input": ["test.yml"], "without_pipeline": True},
                     }
                 ],
             },
@@ -867,12 +912,11 @@ def test_load_rule_empty_file():
         # Test disable pipeline check
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
+                "defaults": {"conversion": {}},
+                "configurations": [
                     {
                         "name": "test_no_pipeline_check",
-                        "input": ["test.yml"],
-                        "pipeline_check": False,
+                        "conversion": {"input": ["test.yml"], "pipeline_check": False},
                     }
                 ],
             },
@@ -896,12 +940,11 @@ def test_load_rule_empty_file():
         # Test fail unsupported instead of skip
         (
             {
-                "conversion_defaults": {"skip_unsupported": False},
-                "conversions": [
+                "defaults": {"conversion": {"skip_unsupported": False}},
+                "configurations": [
                     {
                         "name": "test_fail",
-                        "input": ["test.yml"],
-                        "fail_unsupported": True,
+                        "conversion": {"input": ["test.yml"], "fail_unsupported": True},
                     }
                 ],
             },
@@ -925,12 +968,11 @@ def test_load_rule_empty_file():
         # Test json indent
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
+                "defaults": {"conversion": {}},
+                "configurations": [
                     {
                         "name": "test_json_indent",
-                        "input": ["test.yml"],
-                        "json_indent": 2,
+                        "conversion": {"input": ["test.yml"], "json_indent": 2},
                     }
                 ],
             },
@@ -954,9 +996,9 @@ def test_load_rule_empty_file():
         # Test verbose
         (
             {
-                "conversion_defaults": {},
-                "conversions": [
-                    {"name": "test_verbose", "input": ["test.yml"], "verbose": True}
+                "defaults": {"conversion": {}},
+                "configurations": [
+                    {"name": "test_verbose", "conversion": {"input": ["test.yml"], "verbose": True}}
                 ],
             },
             [
@@ -977,24 +1019,106 @@ def test_load_rule_empty_file():
                 "--verbose",
             ],
         ),
+        # Test overriding skip_unsupported per conversion (default false, conversion true)
+        (
+            {
+                "defaults": {"conversion": {"skip_unsupported": False}},
+                "configurations": [
+                    {
+                        "name": "test_skip",
+                        "conversion": {"input": ["test.yml"], "skip_unsupported": True},
+                    }
+                ],
+            },
+            [
+                "--target",
+                "loki",
+                "--format",
+                "default",
+                "--file-pattern",
+                "*.yml",
+                "--output",
+                "-",
+                "--encoding",
+                "utf-8",
+                "--json-indent",
+                "0",
+                "--pipeline-check",
+                "--skip-unsupported",
+            ],
+        ),
+        # Test overriding file_pattern per conversion (default *.json, conversion overrides to *.yml)
+        (
+            {
+                "defaults": {"conversion": {"file_pattern": "*.json"}},
+                "configurations": [
+                    {
+                        "name": "test_file_pattern",
+                        "conversion": {"input": ["test.yml"], "file_pattern": "*.yml"},
+                    }
+                ],
+            },
+            [
+                "--target",
+                "loki",
+                "--format",
+                "default",
+                "--file-pattern",
+                "*.yml",
+                "--output",
+                "-",
+                "--encoding",
+                "utf-8",
+                "--json-indent",
+                "0",
+                "--pipeline-check",
+                "--skip-unsupported",
+            ],
+        ),
+        # Test overriding encoding per conversion
+        (
+            {
+                "defaults": {"conversion": {"encoding": "latin1"}},
+                "configurations": [
+                    {
+                        "name": "test_encoding",
+                        "conversion": {"input": ["test.yml"], "encoding": "utf-8"},
+                    }
+                ],
+            },
+            [
+                "--target",
+                "loki",
+                "--format",
+                "default",
+                "--file-pattern",
+                "*.yml",
+                "--output",
+                "-",
+                "--encoding",
+                "utf-8",
+                "--json-indent",
+                "0",
+                "--pipeline-check",
+                "--skip-unsupported",
+            ],
+        ),
         # Test combination of several options
         (
             {
-                "conversion_defaults": {
-                    "target": "elastic",
-                    "format": "custom_default",
-                    "encoding": "latin1",
-                },
-                "conversions": [
+                "defaults": {"conversion": {"target": "elastic", "format": "custom_default", "encoding": "latin1"}},
+                "configurations": [
                     {
                         "name": "test_combo",
-                        "input": ["test.yml"],
-                        "target": "splunk",
-                        "pipelines": ["pipeline.yml"],
-                        "filters": ["filter1"],
-                        "backend_options": {"opt": "val"},
-                        "without_pipeline": True,
-                        "verbose": True,
+                        "conversion": {
+                            "input": ["test.yml"],
+                            "target": "splunk",
+                            "pipelines": ["pipeline.yml"],
+                            "filters": ["filter1"],
+                            "backend_options": {"opt": "val"},
+                            "without_pipeline": True,
+                            "verbose": True,
+                        },
                     }
                 ],
             },
@@ -1057,17 +1181,13 @@ def test_convert_rules_command_args(
     mock_invoke.return_value = mock_result
 
     # Create config with the tested parameters
-    config_dict = DynaconfDict(config_params)
+    config_dict = DynaconfDict({"version": 2, **config_params})
 
     # Mock Dynaconf to accept DynaconfDict
     dynaconf_instance = mock_dynaconf.return_value
     dynaconf_instance.get.side_effect = lambda key, default=None: config_dict.get(
         key, default
     )
-
-    # Apply default settings if omitted
-    if "verbose" not in config_dict:
-        config_dict["verbose"] = False
 
     # Mock is_path to return True for any pipeline paths
     with patch.object(convert, "is_path", side_effect=lambda p, f: True):
@@ -1135,11 +1255,11 @@ def test_convert_rules_command_args(
                         == expected_args[expected_args.index("--target") + 1]
                     )
 
-                    # Format might be different due to conversion_defaults - don't assert strict equality
+                    # Format might be different due to conversion defaults - don't assert strict equality
                     assert "--format" in call_args
 
 
-# Test handling of correlation_method when set in conversion_defaults but not in conversion
+# Test handling of correlation_method when set in defaults but not in conversion
 @patch("glob.glob")
 @patch("os.path.exists")
 @patch("pathlib.Path.is_absolute")
@@ -1175,8 +1295,9 @@ def test_default_correlation_method(
     # Create config with default correlation method
     config_dict = DynaconfDict(
         {
-            "conversion_defaults": {"correlation_method": "default_corr"},
-            "conversions": [{"name": "test_default_corr", "input": ["test.yml"]}],
+            "version": 2,
+            "defaults": {"conversion": {"correlation_method": "default_corr"}},
+            "configurations": [{"name": "test_default_corr", "conversion": {"input": ["test.yml"]}}],
         }
     )
 
@@ -1185,10 +1306,6 @@ def test_default_correlation_method(
     dynaconf_instance.get.side_effect = lambda key, default=None: config_dict.get(
         key, default
     )
-
-    # Apply default settings if omitted
-    if "verbose" not in config_dict:
-        config_dict["verbose"] = False
 
     # Mock is_path to handle pipeline paths
     with patch.object(convert, "is_path", side_effect=lambda p, f: True):
@@ -1207,12 +1324,7 @@ def test_default_correlation_method(
                         config=dynaconf_instance, path_prefix="/tmp", all_rules=True
                     )
 
-                    # Verify the function was called with the right parameters
                     assert mock_invoke.called
-
-                    # The test is verifying that default correlation method
-                    # is being included in the config, not necessarily in the args
-                    # So we just verify the conversion ran successfully
                     assert mock_invoke.call_count > 0
 
 
@@ -1235,6 +1347,7 @@ def test_convert_rules_deletes_conversion_for_deleted_rule(temp_workspace, mock_
 
     # Verify the conversion file was deleted
     assert not conversion_file.exists()
+
 
 def test_filter_rule_fields():
     """Test that the filter_rule_fields function filters the rule fields correctly."""
@@ -1449,13 +1562,15 @@ def test_convert_rules_config_change_reconverts_group(temp_workspace, mock_confi
     even though none of its rule files are in changed_files."""
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(mock_config["conversion_defaults"]),
-            "conversions": [
+            "defaults": {"conversion": dict(mock_config["defaults"]["conversion"])},
+            "configurations": [
                 {
                     "name": "test_conversion",
-                    "input": ["rules/*.yml"],
-                    "target": "splunk",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "target": "splunk",
+                        "format": "default",
+                    },
                 }
             ],
         }
@@ -1490,13 +1605,15 @@ def test_convert_rules_renamed_group_converts_without_deleting_old(
 
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(mock_config["conversion_defaults"]),
-            "conversions": [
+            "defaults": {"conversion": dict(mock_config["defaults"]["conversion"])},
+            "configurations": [
                 {
                     "name": "old_name",
-                    "input": ["rules/*.yml"],
-                    "target": "loki",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 }
             ],
         }
@@ -1523,21 +1640,25 @@ def test_convert_rules_unrelated_group_not_reconverted_on_config_change(
     a sibling group with an unchanged config block stays skipped."""
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(
-                mock_config_two_groups["conversion_defaults"]
-            ),
-            "conversions": [
+            "defaults": {
+                "conversion": dict(mock_config_two_groups["defaults"]["conversion"])
+            },
+            "configurations": [
                 {
                     "name": "group_a",
-                    "input": ["rules/*.yml"],
-                    "target": "loki",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 },
                 {
                     "name": "group_b",
-                    "input": ["rules/*.yml"],
-                    "target": "elastic",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "target": "elastic",
+                        "format": "default",
+                    },
                 },
             ],
         }
@@ -1577,13 +1698,15 @@ def test_convert_rules_config_key_order_does_not_reconvert(temp_workspace, mock_
     in a different order, must not be treated as changed."""
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(mock_config["conversion_defaults"]),
-            "conversions": [
+            "defaults": {"conversion": dict(mock_config["defaults"]["conversion"])},
+            "configurations": [
                 {
-                    "format": "default",
-                    "target": "loki",
-                    "input": ["rules/*.yml"],
                     "name": "test_conversion",
+                    "conversion": {
+                        "format": "default",
+                        "target": "loki",
+                        "input": ["rules/*.yml"],
+                    },
                 }
             ],
         }
@@ -1630,13 +1753,15 @@ def test_convert_rules_config_change_respects_manual_flag(temp_workspace, mock_c
 
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(mock_config["conversion_defaults"]),
-            "conversions": [
+            "defaults": {"conversion": dict(mock_config["defaults"]["conversion"])},
+            "configurations": [
                 {
                     "name": "test_conversion",
-                    "input": ["rules/*.yml"],
-                    "target": "splunk",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "target": "splunk",
+                        "format": "default",
+                    },
                 }
             ],
         }
@@ -1660,10 +1785,10 @@ def test_convert_rules_multiple_new_groups_convert_independently(
     independently of one another."""
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(
-                mock_config_two_groups["conversion_defaults"]
-            ),
-            "conversions": [],
+            "defaults": {
+                "conversion": dict(mock_config_two_groups["defaults"]["conversion"])
+            },
+            "configurations": [],
         }
     )
     mock_config_two_groups._loaded_files = [str(temp_workspace / "config.yaml")]
@@ -1681,33 +1806,40 @@ def test_convert_rules_multiple_new_groups_convert_independently(
 
 
 def test_convert_rules_default_change_reconverts_all_groups(temp_workspace):
-    """A change to a top-level conversion_defaults value affects every group
+    """A change to a top-level defaults.conversion value affects every group
     that inherits it, so the whole repository is reconverted, not just the
     group whose own block happened to change."""
-    shared_conversions = [
-        {"name": "group_a", "input": ["rules/*.yml"]},
-        {"name": "group_b", "input": ["rules/*.yml"]},
+    shared_configurations = [
+        {"name": "group_a", "conversion": {"input": ["rules/*.yml"]}},
+        {"name": "group_b", "conversion": {"input": ["rules/*.yml"]}},
     ]
     config = DynaconfDict(
         {
-            "conversion_defaults": {
-                "target": "splunk",
-                "format": "default",
-                "skip_unsupported": "true",
-                "file_pattern": "*.yml",
+            "version": 2,
+            "defaults": {
+                "conversion": {
+                    # A different but genuinely installed backend, so a real
+                    # sigma-cli invocation for both groups actually succeeds.
+                    "target": "text_query_test",
+                    "format": "default",
+                    "skip_unsupported": "true",
+                    "file_pattern": "*.yml",
+                },
             },
-            "conversions": shared_conversions,
+            "configurations": shared_configurations,
         }
     )
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": {
-                "target": "loki",
-                "format": "default",
-                "skip_unsupported": "true",
-                "file_pattern": "*.yml",
+            "defaults": {
+                "conversion": {
+                    "target": "loki",
+                    "format": "default",
+                    "skip_unsupported": "true",
+                    "file_pattern": "*.yml",
+                },
             },
-            "conversions": shared_conversions,
+            "configurations": shared_configurations,
         }
     )
     config._loaded_files = [str(temp_workspace / "config.yaml")]
@@ -1744,18 +1876,20 @@ def test_convert_rules_dropped_input_entry_deletes_stale_output(
 
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(mock_config["conversion_defaults"]),
-            "conversions": [
+            "defaults": {"conversion": dict(mock_config["defaults"]["conversion"])},
+            "configurations": [
                 {
                     "name": "test_conversion",
-                    "input": ["rules/test.yml", "rules/keep.yml"],
-                    "target": "loki",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/test.yml", "rules/keep.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 }
             ],
         }
     )
-    mock_config["conversions"][0]["input"] = ["rules/keep.yml"]
+    mock_config["configurations"][0]["conversion"]["input"] = ["rules/keep.yml"]
     mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
 
     convert_rules(
@@ -1787,18 +1921,20 @@ def test_convert_rules_narrowed_input_pattern_keeps_still_matched_files(
 
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(mock_config["conversion_defaults"]),
-            "conversions": [
+            "defaults": {"conversion": dict(mock_config["defaults"]["conversion"])},
+            "configurations": [
                 {
                     "name": "test_conversion",
-                    "input": ["rules/*.yml"],
-                    "target": "loki",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/*.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 }
             ],
         }
     )
-    mock_config["conversions"][0]["input"] = ["rules/test.yml"]
+    mock_config["configurations"][0]["conversion"]["input"] = ["rules/test.yml"]
     mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
 
     convert_rules(
@@ -1831,27 +1967,31 @@ def test_convert_rules_reassigned_input_moves_output_between_groups(
 
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(
-                mock_config_two_groups["conversion_defaults"]
-            ),
-            "conversions": [
+            "defaults": {
+                "conversion": dict(mock_config_two_groups["defaults"]["conversion"])
+            },
+            "configurations": [
                 {
                     "name": "group_a",
-                    "input": ["rules/test.yml", "rules/keep.yml"],
-                    "target": "loki",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/test.yml", "rules/keep.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 },
                 {
                     "name": "group_b",
-                    "input": [],
-                    "target": "text_query_test",
-                    "format": "default",
+                    "conversion": {
+                        "input": [],
+                        "target": "text_query_test",
+                        "format": "default",
+                    },
                 },
             ],
         }
     )
-    mock_config_two_groups["conversions"][0]["input"] = ["rules/keep.yml"]
-    mock_config_two_groups["conversions"][1]["input"] = ["rules/test.yml"]
+    mock_config_two_groups["configurations"][0]["conversion"]["input"] = ["rules/keep.yml"]
+    mock_config_two_groups["configurations"][1]["conversion"]["input"] = ["rules/test.yml"]
     mock_config_two_groups._loaded_files = [str(temp_workspace / "config.yaml")]
 
     convert_rules(
@@ -1892,18 +2032,20 @@ def test_convert_rules_dropped_input_entry_respects_manual_flag(
 
     previous_config = DynaconfDict(
         {
-            "conversion_defaults": dict(mock_config["conversion_defaults"]),
-            "conversions": [
+            "defaults": {"conversion": dict(mock_config["defaults"]["conversion"])},
+            "configurations": [
                 {
                     "name": "test_conversion",
-                    "input": ["rules/test.yml", "rules/keep.yml"],
-                    "target": "loki",
-                    "format": "default",
+                    "conversion": {
+                        "input": ["rules/test.yml", "rules/keep.yml"],
+                        "target": "loki",
+                        "format": "default",
+                    },
                 }
             ],
         }
     )
-    mock_config["conversions"][0]["input"] = ["rules/keep.yml"]
+    mock_config["configurations"][0]["conversion"]["input"] = ["rules/keep.yml"]
     mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
 
     convert_rules(

--- a/integration-test/config.yml
+++ b/integration-test/config.yml
@@ -1,69 +1,81 @@
+version: 2
 folders:
   conversion_path: "./conversions"
   deployment_path: "./deployments"
-conversion_defaults:
-  target: loki
-  format: default
-  skip_unsupported: true
-  file_pattern: "*.yml"
-  data_source: grafanacloud-logs
-conversions:
+defaults:
+  conversion:
+    target: loki
+    format: default
+    skip_unsupported: true
+    file_pattern: "*.yml"
+  integration:
+    data_source: grafanacloud-logs
+    folder_id: ae9ojcgwmy48wf # sigma-rule-deployment
+    org_id: 1
+    test_queries: false # Whether to test the queries against the datasource
+    from: "now-1h"
+    to: "now"
+  deployment:
+    grafana_instance: https://securityops.grafana-dev.net
+configurations:
   - name: faulty
-    input:
-      - "rules/faulty.yml"
-    backend_options:
-      case_sensitive: true
-    pipelines:
-      - pipelines/datasources/test-1.yml
-      - pipelines/test-1.yml
-    rule_group: Every 1 Hour
-    time_window: 1h
+    conversion:
+      input:
+        - "rules/faulty.yml"
+      backend_options:
+        case_sensitive: true
+      pipelines:
+        - pipelines/datasources/test-1.yml
+        - pipelines/test-1.yml
+    integration:
+      rule_group: Every 1 Hour
+      time_window: 1h
   - name: github_audit
-    input:
-      - "rules/test*"
-    backend_options:
-      case_sensitive: true
-    pipelines:
-      - pipelines/datasources/test-1.yml
-      - pipelines/test-1.yml
-    rule_group: Every 1 Hour
-    time_window: 1h
+    conversion:
+      input:
+        - "rules/test*"
+      backend_options:
+        case_sensitive: true
+      pipelines:
+        - pipelines/datasources/test-1.yml
+        - pipelines/test-1.yml
+    integration:
+      rule_group: Every 1 Hour
+      time_window: 1h
   - name: combine_queries
-    input:
-      - "rules/condition-split.yml"
-    backend_options:
-      case_sensitive: true
-    pipelines:
-      - pipelines/datasources/test-1.yml
-    rule_group: Every 1 Hour
-    time_window: 1h
+    conversion:
+      input:
+        - "rules/condition-split.yml"
+      backend_options:
+        case_sensitive: true
+      pipelines:
+        - pipelines/datasources/test-1.yml
+    integration:
+      rule_group: Every 1 Hour
+      time_window: 1h
   # Two conversions of the same rule used to exercise the "manual" flag feature.
   # manual_explicit: fixtures are seeded already carrying the flag.
   # manual_backfill: fixtures are seeded without the flag (a human edit) so the
   # action must detect the change and backfill the flag before regenerating.
   - name: manual_explicit
-    input:
-      - "rules/manual-test.yml"
-    backend_options:
-      case_sensitive: true
-    pipelines:
-      - pipelines/datasources/test-1.yml
-    rule_group: Every 1 Hour
-    time_window: 1h
+    conversion:
+      input:
+        - "rules/manual-test.yml"
+      backend_options:
+        case_sensitive: true
+      pipelines:
+        - pipelines/datasources/test-1.yml
+    integration:
+      rule_group: Every 1 Hour
+      time_window: 1h
   - name: manual_backfill
-    input:
-      - "rules/manual-test.yml"
-    backend_options:
-      case_sensitive: true
-    pipelines:
-      - pipelines/datasources/test-1.yml
-    rule_group: Every 1 Hour
-    time_window: 1h
-integration:
-  folder_id: ae9ojcgwmy48wf # sigma-rule-deployment
-  org_id: 1
-  test_queries: false # Whether to test the queries against the datasource
-  from: "now-1h"
-  to: "now"
-deployment:
-  grafana_instance: https://securityops.grafana-dev.net
+    conversion:
+      input:
+        - "rules/manual-test.yml"
+      backend_options:
+        case_sensitive: true
+      pipelines:
+        - pipelines/datasources/test-1.yml
+    integration:
+      rule_group: Every 1 Hour
+      time_window: 1h


### PR DESCRIPTION
Refactors convert.py to read the v2 config structure (defaults.conversion + configurations[].conversion) instead of the flat v1 format (conversion_defaults + conversions[]).

Key changes:
- Parse defaults from config.defaults.conversion and per-config overrides from each entry in config.configurations
- Add version validation: raises ValueError if version != 2
- Add per-conversion overrides for skip_unsupported, file_pattern, encoding, required_rule_fields (tested separately per conversion)
- Add filter_rule_fields() to apply required_rule_fields filtering
- Extend test suite: version validation, per-conversion arg overrides, per-conversion required_rule_fields behaviour