### PR TITLE
Don't attempt to create main update PR if it already exists

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -192,13 +192,18 @@ jobs:
           git commit -m "update main branch to relevant hash" --allow-empty
 
           git push origin "integration-test-main-update-${GITHUB_PR_NUMBER}" --force
-          gh pr create \
-            --title "Integration Test Main Update ${GITHUB_PR_NUMBER}" \
-            --body "This PR updates the main branch to the relevant hash for grafana/sigma-rule-deployment#${GITHUB_PR_NUMBER}" \
-            --head "integration-test-main-update-${GITHUB_PR_NUMBER}" \
-            --base main \
-            --label "automated" \
-            --draft
+
+          RESULT=$(gh pr list --json id,title -H "integration-test-main-update-${GITHUB_PR_NUMBER}" | jq -r '. | length')
+
+          if [ "$RESULT" -eq 0 ]; then
+            gh pr create \
+              --title "Integration Test Main Update ${GITHUB_PR_NUMBER}" \
+              --body "This PR updates the main branch to the relevant hash for grafana/sigma-rule-deployment#${GITHUB_PR_NUMBER}" \
+              --head "integration-test-main-update-${GITHUB_PR_NUMBER}" \
+              --base main \
+              --label "automated" \
+              --draft
+          fi
           sleep 10 # wait for the PR checks to start...
 
           # wait for the required PR checks to complete


### PR DESCRIPTION
When an integration test run successfully created a PR to update the main branch in the integration repo, but failed to merge it for some reason, subsequent runs of the integration test action would fail as it unconditionally tried to create a new PR for the same branch, which generated an error and failed the job. 

This change checks for the existence of such a PR and skips the create step when it already exists.