### PR TITLE
fix: Do not wrap with sum if query is already a loki metric query

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,8 @@ linters:
       - builtin$
       - examples$
   settings:
+    goconst:
+      ignore-tests: true
     gosec:
       excludes:
         - G117

--- a/internal/integrate/dsquery.go
+++ b/internal/integrate/dsquery.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/sigma-rule-deployment/shared"
 )
 
+const elasticsearchMetricTypeCount = "count"
+
 // DatasourceQuery is an interface for executing Grafana datasource queries
 type DatasourceQuery interface {
 	GetDatasource(dsName, baseURL, apiKey string, timeout time.Duration) (*GrafanaDatasource, error)
@@ -136,7 +138,7 @@ func (h *HTTPDatasourceQuery) ExecuteQuery(
 			},
 			Metrics: []Metric{
 				{
-					Type: "count",
+					Type: elasticsearchMetricTypeCount,
 					ID:   "1",
 				},
 			},

--- a/internal/integrate/integrator.go
+++ b/internal/integrate/integrator.go
@@ -675,7 +675,7 @@ func createAlertQuery(query string, refID string, datasource string, timerange m
 	case datasourceType == shared.Elasticsearch:
 		// Based on the Elasticsearch data source plugin
 		// https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/dataquery.gen.ts
-		alertQuery.Model = json.RawMessage(fmt.Sprintf(`{"refId":"%s","datasource":{"type":"elasticsearch","uid":"%s"},"query":"%s","alias":"","metrics":[{"type":"count","id":"1"}],"bucketAggs":[{"type":"date_histogram","id":"2","settings":{"interval":"auto"}}],"intervalMs":2000,"maxDataPoints":1354,"timeField":"@timestamp"}`, refID, datasource, escapedQuery))
+		alertQuery.Model = json.RawMessage(fmt.Sprintf(`{"refId":"%s","datasource":{"type":"elasticsearch","uid":"%s"},"query":"%s","alias":"","metrics":[{"type":"%s","id":"1"}],"bucketAggs":[{"type":"date_histogram","id":"2","settings":{"interval":"auto"}}],"intervalMs":2000,"maxDataPoints":1354,"timeField":"@timestamp"}`, refID, datasource, escapedQuery, elasticsearchMetricTypeCount))
 	default:
 		// try a basic query
 		fmt.Printf("WARNING: Using generic query model for the data source type %s; if these queries don't work, try configuring a custom query_model\n", datasourceType)

--- a/internal/integrate/integrator.go
+++ b/internal/integrate/integrator.go
@@ -628,6 +628,28 @@ func getRuleUID(conversionName string, conversionID uuid.UUID) string {
 	return fmt.Sprintf("%x", hash)
 }
 
+// lokiMetricQueryPrefixes are PromQL/LogQL aggregation prefixes emitted by Sigma correlation
+// converters and other metric query generators. Log queries (stream selectors) start with "{".
+var lokiMetricQueryPrefixes = []string{
+	"sum",
+	"count",
+	"avg",
+	"min",
+	"max",
+}
+
+// isLokiMetricQuery reports whether query is already a Loki metric query and should not be
+// wrapped in sum(count_over_time(...)).
+func isLokiMetricQuery(query string) bool {
+	trimmed := strings.TrimSpace(query)
+	for _, prefix := range lokiMetricQueryPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // createAlertQuery creates an AlertQuery based on the target data source and configuration
 func createAlertQuery(query string, refID string, datasource string, timerange model.RelativeTimeRange, config model.ConversionConfig, defaultConf model.ConversionConfig) (model.AlertQuery, error) {
 	datasourceType := shared.GetConfigValue(config.DataSourceType, defaultConf.DataSourceType, shared.GetConfigValue(config.Target, defaultConf.Target, shared.Loki))
@@ -635,8 +657,9 @@ func createAlertQuery(query string, refID string, datasource string, timerange m
 
 	// Modify query based on target data source
 	if datasourceType == shared.Loki {
-		// if the query is not a metric query, we need to add a sum aggregation to it
-		if !strings.HasPrefix(query, "sum") {
+		// Log queries must be converted to metric queries for Grafana alerting. Correlation rules
+		// and other converters already emit metric queries (e.g. sum by (...), count without (...)).
+		if !isLokiMetricQuery(query) {
 			query = fmt.Sprintf("sum(count_over_time(%s[$__auto]))", query)
 		}
 	}

--- a/internal/integrate/integrator.go
+++ b/internal/integrate/integrator.go
@@ -628,18 +628,8 @@ func getRuleUID(conversionName string, conversionID uuid.UUID) string {
 	return fmt.Sprintf("%x", hash)
 }
 
-// lokiMetricQueryPrefixes are PromQL/LogQL aggregation prefixes emitted by Sigma correlation
-// converters and other metric query generators. Log queries (stream selectors) start with "{".
-var lokiMetricQueryPrefixes = []string{
-	"sum",
-	"count",
-	"avg",
-	"min",
-	"max",
-}
+var lokiMetricQueryPrefixes = []string{"sum", "count", "avg", "min", "max"}
 
-// isLokiMetricQuery reports whether query is already a Loki metric query and should not be
-// wrapped in sum(count_over_time(...)).
 func isLokiMetricQuery(query string) bool {
 	trimmed := strings.TrimSpace(query)
 	for _, prefix := range lokiMetricQueryPrefixes {
@@ -655,10 +645,7 @@ func createAlertQuery(query string, refID string, datasource string, timerange m
 	datasourceType := shared.GetConfigValue(config.DataSourceType, defaultConf.DataSourceType, shared.GetConfigValue(config.Target, defaultConf.Target, shared.Loki))
 	customModel := shared.GetConfigValue(config.QueryModel, defaultConf.QueryModel, "")
 
-	// Modify query based on target data source
 	if datasourceType == shared.Loki {
-		// Log queries must be converted to metric queries for Grafana alerting. Correlation rules
-		// and other converters already emit metric queries (e.g. sum by (...), count without (...)).
 		if !isLokiMetricQuery(query) {
 			query = fmt.Sprintf("sum(count_over_time(%s[$__auto]))", query)
 		}

--- a/internal/integrate/integrator_test.go
+++ b/internal/integrate/integrator_test.go
@@ -34,22 +34,12 @@ func TestConvertToAlert(t *testing.T) {
 		wantCombinerExpression string
 	}{
 		{
-			name: "value_count correlation metric query is not wrapped",
-			queries: []string{
-				`count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name=` + "`gh-audit-logs`" + `} | json [5m]))) > 3`,
-			},
-			titles: "GitHub Repository Zip Download Threshold by Actor",
-			rule: &model.ProvisionedAlertRule{
-				UID: "9e2532c1",
-			},
-			convConfig: model.ConversionConfig{
-				Name:       "github_audits_5m",
-				Target:     "loki",
-				DataSource: "grafanacloud-logs",
-				RuleGroup:  "github-audits-5m",
-				TimeWindow: "5m",
-			},
-			wantQueryText: `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name=` + "`gh-audit-logs`" + `} | json [5m])))`,
+			name:          "value_count correlation metric query is not wrapped",
+			queries:       []string{testValueCountMetricQuery},
+			titles:        "GitHub Repository Zip Download Threshold by Actor",
+			rule:          &model.ProvisionedAlertRule{UID: "9e2532c1"},
+			convConfig:    model.ConversionConfig{Name: "github_audits_5m", Target: testLokiTarget, DataSource: testGrafanaCloudLogsDS, RuleGroup: "github-audits-5m", TimeWindow: "5m"},
+			wantQueryText: "count without (event_repo) (sum by (event_actor, event_repo)",
 			wantDuration:  model.Duration(300 * time.Second),
 			wantError:     false,
 		},

--- a/internal/integrate/integrator_test.go
+++ b/internal/integrate/integrator_test.go
@@ -34,6 +34,26 @@ func TestConvertToAlert(t *testing.T) {
 		wantCombinerExpression string
 	}{
 		{
+			name: "value_count correlation metric query is not wrapped",
+			queries: []string{
+				`count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name=` + "`gh-audit-logs`" + `} | json [5m]))) > 3`,
+			},
+			titles: "GitHub Repository Zip Download Threshold by Actor",
+			rule: &model.ProvisionedAlertRule{
+				UID: "9e2532c1",
+			},
+			convConfig: model.ConversionConfig{
+				Name:       "github_audits_5m",
+				Target:     "loki",
+				DataSource: "grafanacloud-logs",
+				RuleGroup:  "github-audits-5m",
+				TimeWindow: "5m",
+			},
+			wantQueryText: `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name=` + "`gh-audit-logs`" + `} | json [5m])))`,
+			wantDuration:  model.Duration(300 * time.Second),
+			wantError:     false,
+		},
+		{
 			name:    "valid new loki query",
 			queries: []string{"{job=`.+`} | json | test=`true`"},
 			titles:  "Alert Rule 1",

--- a/internal/integrate/loki_fixtures_test.go
+++ b/internal/integrate/loki_fixtures_test.go
@@ -1,0 +1,13 @@
+package integrate
+
+const (
+	testLokiTarget                = "loki"
+	testGrafanaCloudLogsDS        = "grafanacloud-logs"
+	testEventCountMetricQuery     = `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`
+	testValueCountMetricQuery     = testValueCountMetricQueryBody + ` > 3`
+	testValueCountMetricQueryBody = `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m])))`
+	testWrappedLogQuery           = `{job=~".+"} | json | test="true"`
+	testWrappedLogQueryExpr       = `sum(count_over_time({job=~".+"} | json | test="true"[$__auto]))`
+	testGhAuditLogQuery           = "{name=`gh-audit-logs`,action=`repo.download_zip`} | json | event_action=~`(?i)^repo\\.download_zip$`"
+	testGhAuditLogQueryExpr       = "sum(count_over_time({name=`gh-audit-logs`,action=`repo.download_zip`} | json | event_action=~`(?i)^repo\\.download_zip$`[$__auto]))"
+)

--- a/internal/integrate/metric_query_test.go
+++ b/internal/integrate/metric_query_test.go
@@ -1,0 +1,76 @@
+package integrate
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grafana/sigma-rule-deployment/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLokiMetricQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{
+			name:  "log query stream selector",
+			query: `{name="gh-audit-logs"} | json`,
+			want:  false,
+		},
+		{
+			name:  "event_count correlation",
+			query: `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`,
+			want:  true,
+		},
+		{
+			name:  "value_count correlation",
+			query: `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m]))) > 3`,
+			want:  true,
+		},
+		{
+			name:  "leading whitespace metric query",
+			query: `  count without (event_repo) (sum by (event_actor) (count_over_time({name="x"} [5m]))) > 1`,
+			want:  true,
+		},
+		{
+			name:  "avg aggregation",
+			query: `avg by (host) (rate({job="app"}[5m]))`,
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isLokiMetricQuery(tt.query))
+		})
+	}
+}
+
+func TestCreateAlertQuery_LokiValueCountCorrelation(t *testing.T) {
+	correlationQuery := `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name=` + "`gh-audit-logs`" + `,action=` + "`repo.download_zip`" + `} | json [5m]))) > 3`
+
+	alertQuery, err := createAlertQuery(
+		correlationQuery,
+		"A0",
+		"grafanacloud-logs",
+		model.RelativeTimeRange{From: model.Duration(5 * time.Minute), To: 0},
+		model.ConversionConfig{Target: "loki", DataSource: "grafanacloud-logs"},
+		model.ConversionConfig{Target: "loki", DataSource: "grafanacloud-logs"},
+	)
+	require.NoError(t, err)
+
+	var modelFields map[string]any
+	require.NoError(t, json.Unmarshal(alertQuery.Model, &modelFields))
+
+	expr, ok := modelFields["expr"].(string)
+	require.True(t, ok)
+	assert.Equal(t, correlationQuery, expr)
+	assert.NotContains(t, expr, "sum(count_over_time(count without")
+}

--- a/internal/integrate/metric_query_test.go
+++ b/internal/integrate/metric_query_test.go
@@ -2,6 +2,7 @@ package integrate
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,31 +19,17 @@ func TestIsLokiMetricQuery(t *testing.T) {
 		query string
 		want  bool
 	}{
-		{
-			name:  "log query stream selector",
-			query: `{name="gh-audit-logs"} | json`,
-			want:  false,
-		},
-		{
-			name:  "event_count correlation",
-			query: `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`,
-			want:  true,
-		},
-		{
-			name:  "value_count correlation",
-			query: `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m]))) > 3`,
-			want:  true,
-		},
-		{
-			name:  "leading whitespace metric query",
-			query: `  count without (event_repo) (sum by (event_actor) (count_over_time({name="x"} [5m]))) > 1`,
-			want:  true,
-		},
-		{
-			name:  "avg aggregation",
-			query: `avg by (host) (rate({job="app"}[5m]))`,
-			want:  true,
-		},
+		{name: "log query stream selector", query: `{name="gh-audit-logs"} | json`, want: false},
+		{name: "log query with line filters", query: `{job=~".+"} |~ "error" | json | level="error"`, want: false},
+		{name: "log query with label filter", query: `{name="okta-logs",eventType="user.session.start"} | json | event_outcome="success"`, want: false},
+
+		{name: "sum by event_count correlation", query: `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`, want: true},
+		{name: "sum without aggregation", query: `sum without (instance) (count_over_time({job="app"} | json [1h]))`, want: true},
+		{name: "value_count correlation", query: `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m]))) > 3`, want: true},
+		{name: "count with leading whitespace", query: `  count without (event_repo) (sum by (event_actor) (count_over_time({name="x"} [5m]))) > 1`, want: true},
+		{name: "avg by host", query: `avg by (host) (rate({job="app"} | json [5m]))`, want: true},
+		{name: "min over time", query: `min by (pod) (min_over_time({namespace="prod"} | json | unwrap bytes [5m]))`, want: true},
+		{name: "max over time", query: `max by (pod) (max_over_time({namespace="prod"} | json | unwrap bytes [5m]))`, want: true},
 	}
 
 	for _, tt := range tests {
@@ -53,24 +40,84 @@ func TestIsLokiMetricQuery(t *testing.T) {
 	}
 }
 
-func TestCreateAlertQuery_LokiValueCountCorrelation(t *testing.T) {
-	correlationQuery := `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name=` + "`gh-audit-logs`" + `,action=` + "`repo.download_zip`" + `} | json [5m]))) > 3`
+func TestCreateAlertQuery_LokiWrapping(t *testing.T) {
+	t.Parallel()
 
-	alertQuery, err := createAlertQuery(
-		correlationQuery,
-		"A0",
-		"grafanacloud-logs",
-		model.RelativeTimeRange{From: model.Duration(5 * time.Minute), To: 0},
-		model.ConversionConfig{Target: "loki", DataSource: "grafanacloud-logs"},
-		model.ConversionConfig{Target: "loki", DataSource: "grafanacloud-logs"},
-	)
-	require.NoError(t, err)
+	lokiConfig := model.ConversionConfig{Target: "loki", DataSource: "grafanacloud-logs"}
+	timerange := model.RelativeTimeRange{From: model.Duration(5 * time.Minute), To: 0}
 
-	var modelFields map[string]any
-	require.NoError(t, json.Unmarshal(alertQuery.Model, &modelFields))
+	tests := []struct {
+		name      string
+		input     string
+		wantWrap  bool
+		wantExact string
+	}{
+		{
+			name:      "wraps standard log query",
+			input:     `{job=~".+"} | json | test="true"`,
+			wantWrap:  true,
+			wantExact: `sum(count_over_time({job=~".+"} | json | test="true"[$__auto]))`,
+		},
+		{
+			name:     "wraps github audit log query",
+			input:    "{name=`gh-audit-logs`,action=`repo.download_zip`} | json | event_action=~`(?i)^repo\\.download_zip$`",
+			wantWrap: true,
+			wantExact: "sum(count_over_time({name=`gh-audit-logs`,action=`repo.download_zip`} | json | event_action=~`(?i)^repo\\.download_zip$`[$__auto]))",
+		},
+		{
+			name:      "preserves event_count correlation metric query",
+			input:     `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`,
+			wantWrap:  false,
+			wantExact: `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`,
+		},
+		{
+			name:      "preserves value_count correlation metric query",
+			input:     `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m]))) > 3`,
+			wantWrap:  false,
+			wantExact: `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m]))) > 3`,
+		},
+		{
+			name:      "preserves avg metric query",
+			input:     `avg by (host) (rate({job="app"} | json [5m])) > 0.5`,
+			wantWrap:  false,
+			wantExact: `avg by (host) (rate({job="app"} | json [5m])) > 0.5`,
+		},
+		{
+			name:      "preserves min metric query",
+			input:     `min by (pod) (min_over_time({namespace="prod"} | json [5m]))`,
+			wantWrap:  false,
+			wantExact: `min by (pod) (min_over_time({namespace="prod"} | json [5m]))`,
+		},
+		{
+			name:      "preserves max metric query",
+			input:     `max by (pod) (max_over_time({namespace="prod"} | json [5m]))`,
+			wantWrap:  false,
+			wantExact: `max by (pod) (max_over_time({namespace="prod"} | json [5m]))`,
+		},
+	}
 
-	expr, ok := modelFields["expr"].(string)
-	require.True(t, ok)
-	assert.Equal(t, correlationQuery, expr)
-	assert.NotContains(t, expr, "sum(count_over_time(count without")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			alertQuery, err := createAlertQuery(tt.input, "A0", "grafanacloud-logs", timerange, lokiConfig, lokiConfig)
+			require.NoError(t, err)
+
+			var modelFields map[string]any
+			require.NoError(t, json.Unmarshal(alertQuery.Model, &modelFields))
+
+			expr, ok := modelFields["expr"].(string)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantExact, expr)
+
+			if tt.wantWrap {
+				assert.True(t, strings.HasPrefix(expr, "sum(count_over_time("))
+				assert.Contains(t, expr, "[$__auto]")
+				assert.False(t, isLokiMetricQuery(tt.input))
+			} else {
+				assert.True(t, isLokiMetricQuery(tt.input))
+				assert.NotContains(t, expr, "[$__auto]")
+			}
+		})
+	}
 }

--- a/internal/integrate/metric_query_test.go
+++ b/internal/integrate/metric_query_test.go
@@ -23,9 +23,9 @@ func TestIsLokiMetricQuery(t *testing.T) {
 		{name: "log query with line filters", query: `{job=~".+"} |~ "error" | json | level="error"`, want: false},
 		{name: "log query with label filter", query: `{name="okta-logs",eventType="user.session.start"} | json | event_outcome="success"`, want: false},
 
-		{name: "sum by event_count correlation", query: `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`, want: true},
+		{name: "sum by event_count correlation", query: testEventCountMetricQuery, want: true},
 		{name: "sum without aggregation", query: `sum without (instance) (count_over_time({job="app"} | json [1h]))`, want: true},
-		{name: "value_count correlation", query: `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m]))) > 3`, want: true},
+		{name: "value_count correlation", query: testValueCountMetricQuery, want: true},
 		{name: "count with leading whitespace", query: `  count without (event_repo) (sum by (event_actor) (count_over_time({name="x"} [5m]))) > 1`, want: true},
 		{name: "avg by host", query: `avg by (host) (rate({job="app"} | json [5m]))`, want: true},
 		{name: "min over time", query: `min by (pod) (min_over_time({namespace="prod"} | json | unwrap bytes [5m]))`, want: true},
@@ -43,7 +43,7 @@ func TestIsLokiMetricQuery(t *testing.T) {
 func TestCreateAlertQuery_LokiWrapping(t *testing.T) {
 	t.Parallel()
 
-	lokiConfig := model.ConversionConfig{Target: "loki", DataSource: "grafanacloud-logs"}
+	lokiConfig := model.ConversionConfig{Target: testLokiTarget, DataSource: testGrafanaCloudLogsDS}
 	timerange := model.RelativeTimeRange{From: model.Duration(5 * time.Minute), To: 0}
 
 	tests := []struct {
@@ -54,27 +54,27 @@ func TestCreateAlertQuery_LokiWrapping(t *testing.T) {
 	}{
 		{
 			name:      "wraps standard log query",
-			input:     `{job=~".+"} | json | test="true"`,
+			input:     testWrappedLogQuery,
 			wantWrap:  true,
-			wantExact: `sum(count_over_time({job=~".+"} | json | test="true"[$__auto]))`,
+			wantExact: testWrappedLogQueryExpr,
 		},
 		{
-			name:     "wraps github audit log query",
-			input:    "{name=`gh-audit-logs`,action=`repo.download_zip`} | json | event_action=~`(?i)^repo\\.download_zip$`",
-			wantWrap: true,
-			wantExact: "sum(count_over_time({name=`gh-audit-logs`,action=`repo.download_zip`} | json | event_action=~`(?i)^repo\\.download_zip$`[$__auto]))",
+			name:      "wraps github audit log query",
+			input:     testGhAuditLogQuery,
+			wantWrap:  true,
+			wantExact: testGhAuditLogQueryExpr,
 		},
 		{
 			name:      "preserves event_count correlation metric query",
-			input:     `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`,
+			input:     testEventCountMetricQuery,
 			wantWrap:  false,
-			wantExact: `sum by (event_actor) (count_over_time({name="gh-audit-logs"} | json [5m])) > 3`,
+			wantExact: testEventCountMetricQuery,
 		},
 		{
 			name:      "preserves value_count correlation metric query",
-			input:     `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m]))) > 3`,
+			input:     testValueCountMetricQuery,
 			wantWrap:  false,
-			wantExact: `count without (event_repo) (sum by (event_actor, event_repo) (count_over_time({name="gh-audit-logs"} | json [5m]))) > 3`,
+			wantExact: testValueCountMetricQuery,
 		},
 		{
 			name:      "preserves avg metric query",
@@ -100,7 +100,7 @@ func TestCreateAlertQuery_LokiWrapping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			alertQuery, err := createAlertQuery(tt.input, "A0", "grafanacloud-logs", timerange, lokiConfig, lokiConfig)
+			alertQuery, err := createAlertQuery(tt.input, "A0", testGrafanaCloudLogsDS, timerange, lokiConfig, lokiConfig)
 			require.NoError(t, err)
 
 			var modelFields map[string]any


### PR DESCRIPTION
This fixes a bug with integrate double-wrapping Loki metric queries that do not start with sum.

Sigma value_count correlation rules convert to LogQL like `count without (event_repo) (sum by (...)(count_over_time(...))) > N`. Integrate only treated queries starting with sum as metric queries, so it wrapped these in `sum(count_over_time(...))`, producing invalid alert expressions.

Changes
- Add `isLokiMetricQuery()` to detect existing metric queries (`sum`, `count`, `avg`, `min`, `max` prefixes).
- Use it in `createAlertQuery` instead of `strings.HasPrefix(query, "sum")`.
- Add tests for `value_count` correlation queries and log-query wrapping behavior.