### PR TITLE
Fix "See In Explore" to always populate

### DIFF
--- a/internal/querytest/querytest.go
+++ b/internal/querytest/querytest.go
@@ -167,6 +167,21 @@ func (qt *QueryTester) TestQueries(queries map[string]string, config, defaultCon
 
 	for _, refID := range refIDs {
 		query := queries[refID]
+
+		// Generate explore link first so it's available even if query testing fails
+		// (e.g., auth failure) — the link is a pure deeplink and doesn't depend on
+		// the test response.
+		exploreLink, err := GenerateExploreLink(
+			query, datasource, datasourceType, config, defaultConf,
+			qt.config.DeployerConfig.GrafanaInstance,
+			qt.config.IntegratorConfig.From,
+			qt.config.IntegratorConfig.To,
+			qt.config.IntegratorConfig.OrgID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error generating explore link: %v", err)
+		}
+
 		resp, err := integrate.TestQuery(
 			query,
 			datasource,
@@ -182,25 +197,13 @@ func (qt *QueryTester) TestQueries(queries map[string]string, config, defaultCon
 			return []model.QueryTestResult{
 				{
 					Datasource: datasource,
-					Link:       "",
+					Link:       exploreLink,
 					Stats: model.Stats{
 						Fields: make(map[string]string),
 						Errors: []string{err.Error()},
 					},
 				},
 			}, fmt.Errorf("error testing query %s: %v", query, err)
-		}
-
-		// Generate explore link based on datasource type
-		exploreLink, err := GenerateExploreLink(
-			query, datasource, datasourceType, config, defaultConf,
-			qt.config.DeployerConfig.GrafanaInstance,
-			qt.config.IntegratorConfig.From,
-			qt.config.IntegratorConfig.To,
-			qt.config.IntegratorConfig.OrgID,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("error generating explore link: %v", err)
 		}
 		// Parse the response to extract statistics
 		result := model.QueryTestResult{

--- a/internal/querytest/querytest_test.go
+++ b/internal/querytest/querytest_test.go
@@ -202,6 +202,48 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestTestQueriesPreservesExploreLinkOnError(t *testing.T) {
+	// When the underlying datasource query fails (e.g., Grafana auth failure),
+	// the returned QueryTestResult should still carry a usable explore link so
+	// the PR comment links to a real Grafana URL instead of `[See in Explore]()`.
+	config := model.Configuration{
+		ConversionDefaults: model.ConversionConfig{
+			Target:     "loki",
+			DataSource: "test-datasource",
+		},
+		IntegratorConfig: model.IntegrationConfig{
+			OrgID: 1,
+			From:  "now-1h",
+			To:    "now",
+		},
+		DeployerConfig: model.DeploymentConfig{
+			GrafanaInstance: "https://test.grafana.com",
+		},
+	}
+
+	mock := newTestDatasourceQueryWithErrors()
+	mock.AddMockError(`{job="test"}`, fmt.Errorf("401 unauthorized"))
+
+	originalDatasourceQuery := integrate.DefaultDatasourceQuery
+	integrate.DefaultDatasourceQuery = mock
+	defer func() {
+		integrate.DefaultDatasourceQuery = originalDatasourceQuery
+	}()
+
+	queryTester := NewQueryTester(config, nil, 5*time.Second)
+	results, err := queryTester.TestQueries(
+		map[string]string{"A0": `{job="test"}`},
+		model.ConversionConfig{Name: "test_conv"},
+		config.ConversionDefaults,
+	)
+
+	assert.Error(t, err)
+	assert.Len(t, results, 1)
+	assert.NotEmpty(t, results[0].Link, "explore link should be populated even on test error")
+	assert.Contains(t, results[0].Link, "https://test.grafana.com/explore")
+	assert.Len(t, results[0].Stats.Errors, 1)
+}
+
 // testDatasourceQuery is a mock implementation for testing
 type testDatasourceQuery struct {
 	queryLog      []string

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -100,7 +100,8 @@ function buildTestResultsTable(testResults) {
       const bytesProcessed = result.stats.bytesProcessed?.unit
         ? `${result.stats.bytesProcessed.value.toLocaleString()} ${result.stats.bytesProcessed.unit}`.trim()
         : '-';
-      resultTable += `| ${title} | [See in Explore](${result.link}) | ${result.stats.count} | ${executionTime} | ${bytesProcessed} | ${result.stats.errors.length} |\n`;
+      const linkCell = result.link ? `[See in Explore](${result.link})` : '-';
+      resultTable += `| ${title} | ${linkCell} | ${result.stats.count} | ${executionTime} | ${bytesProcessed} | ${result.stats.errors.length} |\n`;
     }
   }
 

--- a/scripts/comment-sigma-results/test/buildTestResultsTable.test.js
+++ b/scripts/comment-sigma-results/test/buildTestResultsTable.test.js
@@ -112,6 +112,29 @@ test('buildTestResultsTable - multiple files with results', () => {
   assert(result.includes('2')); // error count for file2
 });
 
+test('buildTestResultsTable - renders dash when link is empty', () => {
+  const testResults = {
+    '/path/to/file1.json': [
+      {
+        datasource: 'loki',
+        link: '',
+        stats: {
+          count: 0,
+          errors: ['401 unauthorized'],
+          fields: {}
+        }
+      }
+    ]
+  };
+
+  const result = commentModule.buildTestResultsTable(testResults);
+
+  assert(result.includes('file1.json'));
+  assert(!result.includes('[See in Explore]()'), 'should not render empty markdown link');
+  const dataLine = result.split('\n').find(line => line.includes('file1.json'));
+  assert(dataLine.includes('| - |'), 'should render dash in link cell');
+});
+
 test('buildTestResultsTable - handles errors array correctly', () => {
   const testResults = {
     '/path/to/file1.json': [


### PR DESCRIPTION
When a query test fails (e.g., Grafana auth failure), the PR comment's "Link" cell rendered as `[See in Explore]()` — a broken markdown link — because `QueryTestResult.Link` was left empty on the error path.

This change populates the explore deeplink even when the test errors. If for some reason there really is no link generated, we'll generate a `-` in place of an empty deep link.