### PR TITLE
Minor security improvements to workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,7 +28,7 @@ jobs:
       packages: write
     steps:
       - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
       - name: "Login to GitHub Container Registry"
@@ -82,13 +82,13 @@ jobs:
         with:
           github_app: sigma-rule-deployment-app
       - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
           persist-credentials: false
           path: ./sigma-rule-deployment
       - name: Checkout Integration Test
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
           persist-credentials: true

--- a/.github/workflows/close-integration-test.yml
+++ b/.github/workflows/close-integration-test.yml
@@ -5,6 +5,8 @@ on:
     types:
       - closed
 
+permissions: {}
+
 jobs:
   close-integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-integration-test.yml
+++ b/.github/workflows/close-integration-test.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
     steps:
       - name: Get GitHub App Token
         id: get-github-app-token

--- a/.github/workflows/convert-integrate.yml
+++ b/.github/workflows/convert-integrate.yml
@@ -67,6 +67,16 @@ jobs:
       packages: read # to pull the Action docker image
       pull-requests: write # to update the relevant pull request
     steps:
+      - name: Validate vault_path input
+        if: ${{ inputs.vault_path != '' }}
+        env:
+          VAULT_PATH: ${{ inputs.vault_path }}
+        run: |
+          if printf '%s' "$VAULT_PATH" | grep -qP '[\r\n]'; then
+            echo "vault_path must not contain newlines"
+            exit 1
+          fi
+
       - name: Get service account token for instance from Vault
         if: ${{ inputs.vault_path != '' }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
@@ -100,11 +110,19 @@ jobs:
             
             // Check comment body if this is an issue_comment event
             if (context.eventName === 'issue_comment' && context.payload.comment) {
+              const trustedAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+              const authorAssociation = context.payload.comment.author_association;
+              if (!trustedAssociations.includes(authorAssociation)) {
+                console.log(`Ignoring comment from ${context.payload.comment.user.login} (association: ${authorAssociation})`);
+                core.setOutput('convert_all', 'false');
+                return;
+              }
+
               const commentBody = context.payload.comment.body.toLowerCase();
-              
+
               if (commentBody.startsWith('sigma') && commentBody.includes('convert all')) {
                 convertAll = true;
-                
+
                 // React with eyes emoji
                 try {
                   await github.rest.reactions.createForIssueComment({
@@ -125,7 +143,7 @@ jobs:
             console.log(`convert_all set to: ${convertAll}`);
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           ref: ${{ github.event_name == 'issue_comment' && steps.get-pr-branch.outputs.result || github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,16 @@ jobs:
       packages: read # to pull the Action docker image
       pull-requests: write # to update the relevant pull request
     steps:
+      - name: Validate vault_path input
+        if: ${{ inputs.vault_path != '' }}
+        env:
+          VAULT_PATH: ${{ inputs.vault_path }}
+        run: |
+          if printf '%s' "$VAULT_PATH" | grep -qP '[\r\n]'; then
+            echo "vault_path must not contain newlines"
+            exit 1
+          fi
+
       - name: Get service account token for instance from Vault
         if: ${{ inputs.vault_path != '' }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 
@@ -41,10 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 
@@ -77,11 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 
@@ -105,11 +103,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 
@@ -133,11 +130,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 
@@ -160,11 +156,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
       - name: Validate Renovate Config

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -10,9 +10,13 @@ on:
     paths:
       - "renovate.json"
 
+permissions: {}
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
* Ensure all workflows have a permissions block, that is appropriately scoped
* Remove unused `checks: write` permissions
* Ensure all uses of `actions/checkout` are pinned to the same version hash and label in comment
* Prevent extracting multiple secrets via Vault path and embedded newlines
* Restrict triggering of SRD actions by external GitHub users