### PR TITLE
Use GH API to commit and push verified changes

### DIFF
--- a/.github/scripts/checkout-or-create-branch.sh
+++ b/.github/scripts/checkout-or-create-branch.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Checks out <branch>, creating it from <base-branch> if it doesn't exist on
+# the remote yet. Branch creation goes through the GitHub REST API (a ref
+# pointing at an existing, already-verified commit) rather than a local
+# `git push`, for the same reason create-verified-commit.sh exists: the
+# GitHub App token used by callers has no key to sign a local push with, and
+# the target repo requires verified signatures. Ref creation isn't itself a
+# commit, so it isn't subject to that rule.
+#
+# Prints the branch's expected head oid to stdout (for passing as
+# create-verified-commit.sh's expectedHeadOid). Must be run from inside the
+# target repo's working copy, after `git fetch`.
+set -euo pipefail
+
+REPO="$1"
+BRANCH="$2"
+BASE_BRANCH="$3"
+
+if git rev-parse --verify "refs/remotes/origin/${BRANCH}" >/dev/null 2>&1; then
+  git checkout -B "$BRANCH" "origin/${BRANCH}" >&2
+  git rev-parse HEAD
+else
+  BASE_OID=$(git rev-parse "origin/${BASE_BRANCH}")
+  gh api "repos/${REPO}/git/refs" -f ref="refs/heads/${BRANCH}" -f sha="$BASE_OID" >/dev/null
+  git checkout -b "$BRANCH" "origin/${BASE_BRANCH}" >&2
+  echo "$BASE_OID"
+fi

--- a/.github/scripts/create-verified-commit.sh
+++ b/.github/scripts/create-verified-commit.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Creates a commit on an existing remote branch via the GitHub GraphQL API
+# (createCommitOnBranch) instead of `git commit` + `git push`. Commits made
+# this way are automatically signed and marked "Verified" by GitHub, which
+# is required to satisfy org-wide rulesets that mandate verified signatures
+# for bot-authored commits (GitHub Apps have no GPG/SSH key to sign with
+# locally).
+#
+# Must be run from inside the target repo's working copy, after the working
+# tree has been mutated to its desired final state and `git add -A` has
+# staged it.
+set -euo pipefail
+
+REPO="$1"
+BRANCH="$2"
+EXPECTED_HEAD_OID="$3"
+MESSAGE="$4"
+
+# One row per changed file: "<status>\t<path>\t<base64 contents, A/M only>".
+# base64 still runs once per added/modified file (unavoidable I/O), but the
+# JSON array construction below happens in a single jq pass rather than one
+# jq invocation per file.
+CHANGES=$(
+  while IFS=$'\t' read -r status path; do
+    case "$status" in
+      A|M) printf '%s\t%s\t%s\n' "$status" "$path" "$(base64 -w0 "$path")" ;;
+      D)   printf '%s\t%s\t\n' "$status" "$path" ;;
+    esac
+  done < <(git diff --cached --name-status --no-renames)
+)
+
+if [ -z "$CHANGES" ]; then
+  echo "No changes to commit, skipping."
+  exit 0
+fi
+
+jq -R -s \
+  --arg repo "$REPO" \
+  --arg branch "$BRANCH" \
+  --arg oid "$EXPECTED_HEAD_OID" \
+  --arg message "$MESSAGE" \
+  '
+  (split("\n") | map(select(length > 0) | split("\t"))) as $rows |
+  {
+    query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+    variables: { input: {
+      branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+      message: { headline: $message },
+      fileChanges: {
+        additions: [$rows[] | select(.[0] == "A" or .[0] == "M") | {path: .[1], contents: .[2]}],
+        deletions: [$rows[] | select(.[0] == "D") | {path: .[1]}]
+      },
+      expectedHeadOid: $oid
+    }}
+  }' <<<"$CHANGES" | gh api graphql --input -

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -104,15 +104,10 @@ jobs:
         run: |
           git fetch
 
-          STATUS=0
-          git rev-parse --verify "integration-test-pr-${GITHUB_PR_NUMBER}" 2>/dev/null || STATUS=$?
-
-          if [ $STATUS -eq 0 ]; then
-            git checkout "integration-test-pr-${GITHUB_PR_NUMBER}"
-            git pull
-          else
-            git checkout -b "integration-test-pr-${GITHUB_PR_NUMBER}"
-          fi
+          EXPECTED_HEAD_OID=$(../sigma-rule-deployment/.github/scripts/checkout-or-create-branch.sh \
+            grafana/sigma-rule-deployment-integration-test \
+            "integration-test-pr-${GITHUB_PR_NUMBER}" \
+            main)
 
           rm -r ./rules
           rm -r ./pipelines
@@ -129,12 +124,11 @@ jobs:
 
           git add -A
 
-          git config user.email "sigma-rule-deployment-app@grafana.com"
-          git config user.name "Sigma Rule Deployment App"
-
-          git commit -m "update integration test configuration" --allow-empty
-
-          git push origin "integration-test-pr-${GITHUB_PR_NUMBER}" --force
+          ../sigma-rule-deployment/.github/scripts/create-verified-commit.sh \
+            grafana/sigma-rule-deployment-integration-test \
+            "integration-test-pr-${GITHUB_PR_NUMBER}" \
+            "$EXPECTED_HEAD_OID" \
+            "update integration test configuration"
 
           RESULT=$(gh pr list --json id,title -H "integration-test-pr-${GITHUB_PR_NUMBER}" | jq -r '. | length')
 
@@ -158,15 +152,10 @@ jobs:
           git checkout main
           git pull
 
-          STATUS=0
-          git rev-parse --verify "integration-test-main-update-${GITHUB_PR_NUMBER}" 2>/dev/null || STATUS=$?
-
-          if [ $STATUS -eq 0 ]; then
-            git checkout "integration-test-main-update-${GITHUB_PR_NUMBER}"
-            git pull
-          else
-            git checkout -b "integration-test-main-update-${GITHUB_PR_NUMBER}"
-          fi
+          EXPECTED_HEAD_OID=$(../sigma-rule-deployment/.github/scripts/checkout-or-create-branch.sh \
+            grafana/sigma-rule-deployment-integration-test \
+            "integration-test-main-update-${GITHUB_PR_NUMBER}" \
+            main)
 
           sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/convert@.*/uses: grafana\/sigma-rule-deployment\/actions\/convert@$ACTION_SHA/g" ./.github/workflows/convert-integrate-comment-test.yml
           sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/integrate@.*/uses: grafana\/sigma-rule-deployment\/actions\/integrate@$ACTION_SHA/g" ./.github/workflows/convert-integrate-comment-test.yml
@@ -176,9 +165,12 @@ jobs:
           echo "$GITHUB_PR_NUMBER" > github_pr.txt
 
           git add -A
-          git commit -m "update main branch to relevant hash" --allow-empty
 
-          git push origin "integration-test-main-update-${GITHUB_PR_NUMBER}" --force
+          ../sigma-rule-deployment/.github/scripts/create-verified-commit.sh \
+            grafana/sigma-rule-deployment-integration-test \
+            "integration-test-main-update-${GITHUB_PR_NUMBER}" \
+            "$EXPECTED_HEAD_OID" \
+            "update main branch to relevant hash"
 
           RESULT=$(gh pr list --json id,title -H "integration-test-main-update-${GITHUB_PR_NUMBER}" | jq -r '. | length')
 


### PR DESCRIPTION
Recent changes to GitHub means that all Grafana org commits need to be signed before they will be accepted. This uses the GH API to achieve this.

It also separates out the logic for checking out branches into a separate script