### PR TITLE
Update branch creation script to reset on main

### DIFF
--- a/.github/scripts/checkout-or-create-branch.sh
+++ b/.github/scripts/checkout-or-create-branch.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# Checks out <branch>, creating it from <base-branch> if it doesn't exist on
-# the remote yet. Branch creation goes through the GitHub REST API (a ref
-# pointing at an existing, already-verified commit) rather than a local
-# `git push`, for the same reason create-verified-commit.sh exists: the
-# GitHub App token used by callers has no key to sign a local push with, and
-# the target repo requires verified signatures. Ref creation isn't itself a
-# commit, so it isn't subject to that rule.
+# Checks out <branch>, (re)creating it from <base-branch> so it always
+# starts from the current base tip - even if <branch> already existed with
+# stale content that's now diverged from <base-branch>. Callers overwrite
+# the whole working tree after this runs, so history on <branch> is never
+# worth preserving, and always resetting keeps the branch mergeable into
+# <base-branch> instead of accumulating conflicts over repeated runs.
+#
+# Branch creation/reset goes through the GitHub REST API (a ref pointing at
+# an existing, already-verified commit) rather than a local `git push`, for
+# the same reason create-verified-commit.sh exists: the GitHub App token
+# used by callers has no key to sign a local push with, and the target repo
+# requires verified signatures. Ref creation/updates aren't themselves a
+# commit, so they aren't subject to that rule.
 #
 # Prints the branch's expected head oid to stdout (for passing as
 # create-verified-commit.sh's expectedHeadOid). Must be run from inside the
@@ -16,12 +22,13 @@ REPO="$1"
 BRANCH="$2"
 BASE_BRANCH="$3"
 
+BASE_OID=$(git rev-parse "origin/${BASE_BRANCH}")
+
 if git rev-parse --verify "refs/remotes/origin/${BRANCH}" >/dev/null 2>&1; then
-  git checkout -B "$BRANCH" "origin/${BRANCH}" >&2
-  git rev-parse HEAD
+  gh api --method PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" -f sha="$BASE_OID" -F force=true >/dev/null
 else
-  BASE_OID=$(git rev-parse "origin/${BASE_BRANCH}")
   gh api "repos/${REPO}/git/refs" -f ref="refs/heads/${BRANCH}" -f sha="$BASE_OID" >/dev/null
-  git checkout -b "$BRANCH" "origin/${BASE_BRANCH}" >&2
-  echo "$BASE_OID"
 fi
+
+git checkout -B "$BRANCH" "$BASE_OID" >&2
+echo "$BASE_OID"


### PR DESCRIPTION
We keep getting drift from main on integration test PRs, which prevents the integration test check from running (e.g., [this PR](https://github.com/grafana/sigma-rule-deployment/pull/335) didn't run the "Integration Testing - Pull Request" check because its [integration test PR](https://github.com/grafana/sigma-rule-deployment-integration-test/pull/553) has conflicts with main, so didn't run **any** checks). This change should prevent such issues: when an integration test branch for the PR already exists, it will PATCH the base of that branch to the current main ref (throwing away previous history, but this is of limited value), and using this specific approach helps avoid an unnecessary `git push`.

In testing (see below), this is equivalent to closing the old PR and opening a new one.