### PR TITLE
Adds repo ref so gh uploads to calling repo

### DIFF
--- a/.github/workflows/sbom-release.yml
+++ b/.github/workflows/sbom-release.yml
@@ -39,6 +39,7 @@ jobs:
       - name: "Upload SBOM to release"
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.event.release.tag_name || inputs.tag }}
           SBOM_PATH: ${{ steps.export-sbom.outputs.path }}
         run: gh release upload "$TAG" "$SBOM_PATH" --clobber


### PR DESCRIPTION
As the `checkout` step is removed, the gh upload command fails. Adding `GH_REPO` env allows the command to run in the context of the repository from where the workflow is run.