### PR TITLE
Preserve manual modifications to generated files with flag

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -219,8 +219,12 @@ automation commit) and adds the `manual` flag for you in the same "Sigma Rules D
 commit — so your edit is preserved from that point on. When a change is skipped this way, the
 run logs which file was kept.
 
-To hand control of a file back to automation, remove the flag (`manual: true` /
-`annotations.manual`); the next run will regenerate it as normal.
+To hand control of a file back to automation, set the flag to `false`
+(`"manual": false` for conversion files, `"manual": "false"` in a deployment file's
+annotations) rather than deleting it; the next run treats the file as automated again
+and regenerates it. Do **not** just delete the flag key — the auto-detection above
+can't tell a deleted flag from an ordinary human edit, so it would simply add the flag
+back on the next run.
 
 ## Next Steps
 

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -198,6 +198,30 @@ Don't forget to add a `.yamllint` configuration file to keep the YAML linting wo
 
 **Pro tip**: Copy the `.yamllint` file from this repository or create one with your team's preferred YAML style guidelines.
 
+## Preserving Manual Modifications
+
+The converter and integrator regenerate the files under your `conversion_path` (converted
+queries) and `deployment_path` (Grafana alert rules) on every run. If you hand-edit one of
+these generated files, the next automation run would normally overwrite your change.
+
+To keep a generated file under manual control, mark it with a `manual` flag:
+
+- **Conversion files** (JSON): add a top-level `"manual": true`.
+- **Deployment files** (alert rules): add a `"manual": "true"` entry to the rule's
+  `annotations` object (kept as an annotation so the alert-rule schema stays valid).
+
+A file carrying the flag is never overwritten **or** deleted by automation — including when
+its source rule is removed or the file would otherwise be cleaned up as orphaned.
+
+You usually don't need to add the flag by hand. If you edit a generated file and open/update
+a PR, the next automation run detects that a human changed it (by comparing against the last
+automation commit) and adds the `manual` flag for you in the same "Sigma Rules Deployment"
+commit — so your edit is preserved from that point on. When a change is skipped this way, the
+run logs which file was kept.
+
+To hand control of a file back to automation, remove the flag (`manual: true` /
+`annotations.manual`); the next run will regenerate it as normal.
+
 ## Next Steps
 
 Congratulations! 🎉 You've completed the basic setup. Here's what you should do next:

--- a/actions/convert/README.md
+++ b/actions/convert/README.md
@@ -100,7 +100,7 @@ jobs:
   - `rules`: List of rule metadata including ID, title, description, severity, and query
   - `output_file`: Path to the output file relative to the repository root
 - For correlation rules to work correctly, all the related rules must be present in the same file using the `---` notation (multi document) in YAML.
-- **Preserving manual edits**: a conversion file with a top-level `"manual": true` is never overwritten or deleted by the converter. If you edit a conversion file directly (without the flag), the action detects the human change against the last automation commit and backfills `"manual": true` automatically, so your edit is preserved on this and future runs. Remove the flag to hand the file back to automation.
+- **Preserving manual edits**: a conversion file with a top-level `"manual": true` is never overwritten or deleted by the converter. If you edit a conversion file directly (without the flag), the action detects the human change against the last automation commit and backfills `"manual": true` automatically, so your edit is preserved on this and future runs. To hand the file back to automation, set `"manual": false` (don't just delete the key — the backfill can't distinguish a deleted flag from a normal edit and would re-add it).
 
 ## External Dependencies
 

--- a/actions/convert/README.md
+++ b/actions/convert/README.md
@@ -100,6 +100,7 @@ jobs:
   - `rules`: List of rule metadata including ID, title, description, severity, and query
   - `output_file`: Path to the output file relative to the repository root
 - For correlation rules to work correctly, all the related rules must be present in the same file using the `---` notation (multi document) in YAML.
+- **Preserving manual edits**: a conversion file with a top-level `"manual": true` is never overwritten or deleted by the converter. If you edit a conversion file directly (without the flag), the action detects the human change against the last automation commit and backfills `"manual": true` automatically, so your edit is preserved on this and future runs. Remove the flag to hand the file back to automation.
 
 ## External Dependencies
 

--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -85,8 +85,14 @@ runs:
         CHANGED_FILES=$(eval $ACMR_DIFF_COMMAND)
         DELETED_FILES=$(eval $D_DIFF_COMMAND)
 
+        # Conversion output files a human changed since the last automation commit. Unlike
+        # the diffs above (scoped to inputs), this is scoped to the conversion output dir so
+        # the converter can backfill their missing manual flag and preserve the edits.
+        MANUAL_FILES=$(git diff ${PREVIOUS_REF} --name-only --diff-filter=ACMR -- "${CONVERSION_PATH}")
+
         echo all_changed_files=${CHANGED_FILES//\\n/} >> "$GITHUB_OUTPUT"
         echo deleted_files=${DELETED_FILES//\\n/} >> "$GITHUB_OUTPUT"
+        echo manual_files=${MANUAL_FILES//\\n/} >> "$GITHUB_OUTPUT"
 
     - name: Determine Image Reference
       id: image-ref
@@ -108,6 +114,7 @@ runs:
         ALL_RULES: ${{ inputs.all_rules }}
         CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         DELETED_FILES: ${{ steps.changed-files.outputs.deleted_files }}
+        MANUAL_FILES: ${{ steps.changed-files.outputs.manual_files }}
         IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
       run: |
         docker run --rm \
@@ -121,6 +128,7 @@ runs:
             -e ALL_RULES="$ALL_RULES" \
             -e CHANGED_FILES="$CHANGED_FILES" \
             -e DELETED_FILES="$DELETED_FILES" \
+            -e MANUAL_FILES="$MANUAL_FILES" \
             "ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:$IMAGE_REF" \
             convert
 

--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -15,6 +15,34 @@ from sigma.cli.convert import convert
 from yaml import FullLoader, load_all
 
 
+def _json_options(pretty_print: bool) -> int:
+    """Return the orjson options used to write conversion files canonically."""
+    options = json.OPT_NAIVE_UTC | json.OPT_SORT_KEYS
+    if pretty_print:
+        options = options | json.OPT_INDENT_2
+    return options
+
+
+def _read_existing_output(output_file: Path) -> dict[str, Any] | None:
+    """Read and parse an existing conversion output file.
+
+    Returns the parsed dict, or None if the file is absent or cannot be parsed.
+    """
+    if not output_file.exists():
+        return None
+    try:
+        with open(output_file, "rb") as f:
+            return json.loads(f.read())
+    except (ValueError, OSError):
+        return None
+
+
+def _is_manual(output_file: Path) -> bool:
+    """Return True if an existing conversion file is marked as manually maintained."""
+    existing = _read_existing_output(output_file)
+    return bool(existing and existing.get("manual"))
+
+
 def convert_rules(
     config: Dynaconf,
     path_prefix: str | Path,
@@ -23,6 +51,7 @@ def convert_rules(
     all_rules: bool = False,
     changed_files: str = "",
     deleted_files: str = "",
+    manual_files: str = "",
 ) -> None:
     """Convert Sigma rules to the target format per each file in the conversions object
     in the config. The converted files will be saved in the PATH_PREFIX/conversions
@@ -60,6 +89,8 @@ def convert_rules(
         all_rules (bool): Whether to convert all rules.
         changed_files (str): The list of changed files.
         deleted_files (str): The list of deleted files.
+        manual_files (str): Space-separated conversion files a human modified since
+            the last automation commit; missing manual flags are backfilled onto them.
 
     Raises:
         ValueError: Path prefix must be set using GITHUB_WORKSPACE environment variable.
@@ -94,8 +125,8 @@ def convert_rules(
         path_prefix = path_prefix.resolve()
 
     # Check whether we have any files to process
-    if not all_rules and not changed_files and not deleted_files:
-        print("No changed or deleted files identified, but all_rules is false")
+    if not all_rules and not changed_files and not deleted_files and not manual_files:
+        print("No changed, deleted or manual files identified, but all_rules is false")
         exit(0)
 
     # Get the conversion path from the config
@@ -129,6 +160,22 @@ def convert_rules(
     default_json_indent = config.get("conversion_defaults.json_indent", 0)
     default_required_rule_fields = config.get("conversion_defaults.required_rule_fields", [])
     verbose = config.get("verbose", False)
+
+    # Backfill the manual flag onto conversion files a human modified since the last
+    # automation commit. Doing this before the conversion loop means the freshly-added
+    # flag is honoured (and the file preserved) on this same run.
+    for manual_file in (path_prefix / Path(x) for x in manual_files.split(" ") if x):
+        existing = _read_existing_output(manual_file)
+        if existing is None or existing.get("manual"):
+            continue
+        existing["manual"] = True
+        with open(manual_file, "w", encoding=default_encoding) as f:
+            f.write(
+                json.dumps(existing, option=_json_options(pretty_print)).decode(
+                    default_encoding, "blackslashreplace"
+                )
+            )
+        print(f"Marking manually-modified conversion file as manual: {manual_file}")
 
     conversions_to_delete = []
     # Convert Sigma rules to the target format per each conversion object in the config
@@ -333,6 +380,13 @@ def convert_rules(
                 output_filename = output_filename.replace(os.sep, "_")
                 output_file = path_prefix / conversions_output_dir / output_filename
 
+                # Do not overwrite a manually-maintained conversion file.
+                if _is_manual(output_file):
+                    print(
+                        f"Skipping manually-maintained conversion file (not overwriting): {output_file}"
+                    )
+                    continue
+
                 # Filter the rules to only include the required fields, if empty, return the full rule dictionaries
                 required_rule_fields = conversion.get("required_rule_fields", default_required_rule_fields)
 
@@ -347,13 +401,10 @@ def convert_rules(
 
                 # Write the output to a file
                 with open(output_file, "w", encoding=encoding) as f:
-                    options = json.OPT_NAIVE_UTC | json.OPT_SORT_KEYS
-                    if pretty_print:
-                        options = options | json.OPT_INDENT_2
                     f.write(
                         json.dumps(
                             output_data,
-                            option=options,
+                            option=_json_options(pretty_print),
                         ).decode(encoding, "blackslashreplace")
                     )
 
@@ -367,6 +418,11 @@ def convert_rules(
         print("Removing conversions of deleted rules from the output directory")
         for deleted_file in conversions_to_delete:
             if deleted_file.exists():
+                if _is_manual(deleted_file):
+                    print(
+                        f"Keeping manually-maintained conversion file (not deleting): {deleted_file}"
+                    )
+                    continue
                 print(f"Removing {deleted_file}")
                 os.remove(deleted_file)
 

--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -15,12 +15,21 @@ from sigma.cli.convert import convert
 from yaml import FullLoader, load_all
 
 
-def _json_options(pretty_print: bool) -> int:
-    """Return the orjson options used to write conversion files canonically."""
+# The manual flag marks a generated file as manually maintained. Conversion files
+# carry it as a top-level boolean; deployment annotations use the string "true".
+MANUAL_KEY = "manual"
+MANUAL_VALUE = "true"
+
+
+def _write_output(
+    output_file: Path, data: dict[str, Any], pretty_print: bool, encoding: str
+) -> None:
+    """Write `data` to output_file as canonical JSON (sorted keys, optional indent)."""
     options = json.OPT_NAIVE_UTC | json.OPT_SORT_KEYS
     if pretty_print:
         options = options | json.OPT_INDENT_2
-    return options
+    with open(output_file, "w", encoding=encoding) as f:
+        f.write(json.dumps(data, option=options).decode(encoding, "backslashreplace"))
 
 
 def _read_existing_output(output_file: Path) -> dict[str, Any] | None:
@@ -37,10 +46,20 @@ def _read_existing_output(output_file: Path) -> dict[str, Any] | None:
         return None
 
 
+def _manual_is_set(value: Any) -> bool:
+    """Return True if a decoded `manual` value marks a file as manually maintained.
+
+    Accepts the boolean ``true`` used by conversion files and the string ``"true"``
+    used by deployment annotations, so the converter and the (Go) integrator agree
+    on what counts as manual and neither destroys what the other preserves.
+    """
+    return value is True or value == MANUAL_VALUE
+
+
 def _is_manual(output_file: Path) -> bool:
     """Return True if an existing conversion file is marked as manually maintained."""
     existing = _read_existing_output(output_file)
-    return bool(existing and existing.get("manual"))
+    return existing is not None and _manual_is_set(existing.get(MANUAL_KEY))
 
 
 def convert_rules(
@@ -165,16 +184,16 @@ def convert_rules(
     # automation commit. Doing this before the conversion loop means the freshly-added
     # flag is honoured (and the file preserved) on this same run.
     for manual_file in (path_prefix / Path(x) for x in manual_files.split(" ") if x):
-        existing = _read_existing_output(manual_file)
-        if existing is None or existing.get("manual"):
+        # Only touch files inside the conversion output directory.
+        if manual_file.parent != conversions_output_dir:
             continue
-        existing["manual"] = True
-        with open(manual_file, "w", encoding=default_encoding) as f:
-            f.write(
-                json.dumps(existing, option=_json_options(pretty_print)).decode(
-                    default_encoding, "blackslashreplace"
-                )
-            )
+        existing = _read_existing_output(manual_file)
+        # A manual key that is already present (any value) reflects a deliberate
+        # human choice; do not overwrite it.
+        if existing is None or MANUAL_KEY in existing:
+            continue
+        existing[MANUAL_KEY] = True
+        _write_output(manual_file, existing, pretty_print, default_encoding)
         print(f"Marking manually-modified conversion file as manual: {manual_file}")
 
     conversions_to_delete = []
@@ -286,6 +305,19 @@ def convert_rules(
                 )
                 continue
 
+            # Compute the output path up front so a manually-maintained file can be
+            # skipped before the (expensive) conversion runs.
+            rel_input_path = Path(input_file).relative_to(path_prefix)
+            output_filename = f"{name}_{rel_input_path.stem}.json".replace(os.sep, "_")
+            output_file = path_prefix / conversions_output_dir / output_filename
+
+            # Do not overwrite a manually-maintained conversion file.
+            if _is_manual(output_file):
+                print(
+                    f"Skipping manually-maintained conversion file (not overwriting): {output_file}"
+                )
+                continue
+
             args = [
                 "--target",
                 conversion.get("target", default_target),
@@ -373,20 +405,6 @@ def convert_rules(
                     print("No output generated, skipping writing to file")
                     continue
 
-                # Create output filename based on input file path
-                rel_input_path = Path(input_file).relative_to(path_prefix)
-                output_filename = f"{name}_{rel_input_path.stem}.json"
-                # Replace directory separators with underscores
-                output_filename = output_filename.replace(os.sep, "_")
-                output_file = path_prefix / conversions_output_dir / output_filename
-
-                # Do not overwrite a manually-maintained conversion file.
-                if _is_manual(output_file):
-                    print(
-                        f"Skipping manually-maintained conversion file (not overwriting): {output_file}"
-                    )
-                    continue
-
                 # Filter the rules to only include the required fields, if empty, return the full rule dictionaries
                 required_rule_fields = conversion.get("required_rule_fields", default_required_rule_fields)
 
@@ -400,13 +418,7 @@ def convert_rules(
                 }
 
                 # Write the output to a file
-                with open(output_file, "w", encoding=encoding) as f:
-                    f.write(
-                        json.dumps(
-                            output_data,
-                            option=_json_options(pretty_print),
-                        ).decode(encoding, "blackslashreplace")
-                    )
+                _write_output(output_file, output_data, pretty_print, encoding)
 
                 print(f"Output written to {output_file}")
                 print(f"Converting {name} completed with exit code {result.exit_code}")

--- a/actions/convert/main.py
+++ b/actions/convert/main.py
@@ -67,4 +67,5 @@ if __name__ == "__main__":
         all_rules=args.all_rules,
         changed_files=args.changed_files,
         deleted_files=args.deleted_files,
+        manual_files=args.manual_files,
     )

--- a/actions/convert/settings.py
+++ b/actions/convert/settings.py
@@ -68,6 +68,11 @@ def parse_args() -> argparse.Namespace:
         help="List of deleted files",
         default=os.environ.get("DELETED_FILES", ""),
     )
+    parser.add_argument(
+        "--manual-files",
+        help="List of conversion files a human modified since the last automation commit",
+        default=os.environ.get("MANUAL_FILES", ""),
+    )
 
     return parser.parse_args()
 

--- a/actions/convert/test_convert.py
+++ b/actions/convert/test_convert.py
@@ -1088,3 +1088,85 @@ def test_filter_rule_fields():
             "logsource": {"category": "Test Category 2", "product": "Test Product 2", "service": "Test Service 2", "definition": "Test Definition 2"}
         }
     ]
+
+
+def test_convert_rules_skips_manual_conversion(temp_workspace, mock_config):
+    """A conversion file marked manual is not overwritten when its rule changes."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    output_file = conversion_dir / "test_conversion_test.json"
+    manual_content = json.dumps({"manual": True, "queries": ["HAND EDITED"]}).decode(
+        "utf-8"
+    )
+    output_file.write_text(manual_content)
+
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        changed_files="rules/test.yml",
+    )
+
+    # The manual file must be left exactly as the human wrote it.
+    assert output_file.read_text() == manual_content
+
+
+def test_convert_rules_backfills_manual_flag(temp_workspace, mock_config):
+    """A human-modified conversion file listed in manual_files gains the manual flag."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    output_file = conversion_dir / "test_conversion_test.json"
+    output_file.write_text(
+        json.dumps(
+            {"queries": ["HUMAN EDIT"], "conversion_name": "test_conversion"}
+        ).decode("utf-8")
+    )
+
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        manual_files="conversions/test_conversion_test.json",
+    )
+
+    data = json.loads(output_file.read_bytes())
+    assert data["manual"] is True
+    assert data["queries"] == ["HUMAN EDIT"]
+
+
+def test_convert_rules_backfilled_file_not_overwritten(temp_workspace, mock_config):
+    """A human edit is flagged and preserved even when the source rule also changed."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    output_file = conversion_dir / "test_conversion_test.json"
+    output_file.write_text(
+        json.dumps(
+            {"queries": ["HUMAN EDIT"], "conversion_name": "test_conversion"}
+        ).decode("utf-8")
+    )
+
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        changed_files="rules/test.yml",
+        manual_files="conversions/test_conversion_test.json",
+    )
+
+    data = json.loads(output_file.read_bytes())
+    assert data["manual"] is True
+    # The query was not regenerated from the (changed) rule.
+    assert data["queries"] == ["HUMAN EDIT"]
+
+
+def test_convert_rules_keeps_manual_conversion_on_delete(temp_workspace, mock_config):
+    """A manual conversion file is not deleted when its source rule is deleted."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    conversion_file = conversion_dir / "test_conversion_test.json"
+    conversion_file.write_text(json.dumps({"manual": True}).decode("utf-8"))
+
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        deleted_files="rules/test.yml",
+    )
+
+    assert conversion_file.exists()

--- a/actions/convert/test_convert.py
+++ b/actions/convert/test_convert.py
@@ -1170,3 +1170,64 @@ def test_convert_rules_keeps_manual_conversion_on_delete(temp_workspace, mock_co
     )
 
     assert conversion_file.exists()
+
+
+def test_convert_rules_respects_explicit_manual_false(temp_workspace, mock_config):
+    """An explicit manual:false is not re-flagged to true by the backfill."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    output_file = conversion_dir / "test_conversion_test.json"
+    output_file.write_text(
+        json.dumps({"manual": False, "queries": ["HUMAN EDIT"]}).decode("utf-8")
+    )
+
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        manual_files="conversions/test_conversion_test.json",
+    )
+
+    data = json.loads(output_file.read_bytes())
+    assert data["manual"] is False
+
+
+def test_convert_rules_backfill_ignores_files_outside_conversion_dir(
+    temp_workspace, mock_config
+):
+    """The backfill only flags files inside the conversion output directory."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    # A JSON file outside the conversions directory must be left untouched.
+    outside = temp_workspace / "elsewhere.json"
+    outside.write_text(json.dumps({"queries": ["x"]}).decode("utf-8"))
+
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        manual_files="elsewhere.json",
+    )
+
+    data = json.loads(outside.read_bytes())
+    assert "manual" not in data
+
+
+@patch("click.testing.CliRunner.invoke")
+def test_convert_rules_skips_manual_before_conversion(
+    mock_invoke, temp_workspace, mock_config
+):
+    """A manual conversion file is skipped before the (expensive) sigma-cli invoke."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    output_file = conversion_dir / "test_conversion_test.json"
+    output_file.write_text(
+        json.dumps({"manual": True, "queries": ["HAND EDITED"]}).decode("utf-8")
+    )
+
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        changed_files="rules/test.yml",
+    )
+
+    # The skip happens before conversion, so sigma-cli is never invoked.
+    mock_invoke.assert_not_called()

--- a/actions/convert/test_convert.py
+++ b/actions/convert/test_convert.py
@@ -1191,6 +1191,29 @@ def test_convert_rules_respects_explicit_manual_false(temp_workspace, mock_confi
     assert data["manual"] is False
 
 
+def test_convert_rules_regenerates_manual_false_conversion(temp_workspace, mock_config):
+    """The opt-out path: a conversion file set to manual:false is not re-flagged and
+    is regenerated (handed back) when its source rule changes."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    output_file = conversion_dir / "test_conversion_test.json"
+    output_file.write_text(
+        json.dumps({"manual": False, "queries": ["STALE"]}).decode("utf-8")
+    )
+
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        changed_files="rules/test.yml",
+        manual_files="conversions/test_conversion_test.json",
+    )
+
+    data = json.loads(output_file.read_bytes())
+    # Regenerated: fresh output carries no manual key and the real (not stale) query.
+    assert "manual" not in data
+    assert data["queries"] != ["STALE"]
+
+
 def test_convert_rules_backfill_ignores_files_outside_conversion_dir(
     temp_workspace, mock_config
 ):

--- a/actions/integrate/README.md
+++ b/actions/integrate/README.md
@@ -109,7 +109,7 @@ jobs:
 - Only processes files that have been modified since the last commit (or base branch).
 - Use `all_rules: true` to process all conversion files regardless of changes.
 - Obsolete alert rule files are automatically removed when corresponding conversion files are deleted.
-- **Preserving manual edits**: an alert rule file whose `annotations` contain `"manual": "true"` is never overwritten or deleted by the integrator (including orphaned-file cleanup). If you edit an alert rule file directly without the annotation, the action detects the human change against the last automation commit and backfills `"manual": "true"` automatically, preserving your edit on this and future runs. Remove the annotation to hand the file back to automation.
+- **Preserving manual edits**: an alert rule file whose `annotations` contain `"manual": "true"` is never overwritten or deleted by the integrator (including orphaned-file cleanup). If you edit an alert rule file directly without the annotation, the action detects the human change against the last automation commit and backfills `"manual": "true"` automatically, preserving your edit on this and future runs. To hand the file back to automation, set the annotation to `"manual": "false"` (don't just delete it — the backfill can't distinguish a deleted flag from a normal edit and would re-add it).
 
 ### Best Practices
 

--- a/actions/integrate/README.md
+++ b/actions/integrate/README.md
@@ -109,6 +109,7 @@ jobs:
 - Only processes files that have been modified since the last commit (or base branch).
 - Use `all_rules: true` to process all conversion files regardless of changes.
 - Obsolete alert rule files are automatically removed when corresponding conversion files are deleted.
+- **Preserving manual edits**: an alert rule file whose `annotations` contain `"manual": "true"` is never overwritten or deleted by the integrator (including orphaned-file cleanup). If you edit an alert rule file directly without the annotation, the action detects the human change against the last automation commit and backfills `"manual": "true"` automatically, preserving your edit on this and future runs. Remove the annotation to hand the file back to automation.
 
 ### Best Practices
 

--- a/actions/integrate/action.yml
+++ b/actions/integrate/action.yml
@@ -94,6 +94,7 @@ runs:
       shell: bash
       env:
         CONVERSION_PATH: ${{ steps.config-paths.outputs.conversion_path }}
+        DEPLOYMENT_PATH: ${{ steps.config-paths.outputs.deployment_path }}
         PREVIOUS_REF: ${{ steps.commits.outputs.previous-ref }}
         BASE_REF: ${{ steps.commits.outputs.base-commit }}
       run: |
@@ -102,9 +103,13 @@ runs:
         CHANGED_FILES=$(git diff "$PREVIOUS_REF" --name-only --diff-filter=ACMR -- "$CONVERSION_PATH")
         DELETED_FILES=$(git diff "$PREVIOUS_REF" --name-only --diff-filter=D -- "$CONVERSION_PATH")
         TEST_FILES=$(git diff "$BASE_REF" --name-only --diff-filter=ACMR -- "$CONVERSION_PATH")
+        # Deployment files a human changed since the last automation commit, so the
+        # integrator can backfill their missing manual annotation and preserve the edits.
+        MANUAL_FILES=$(git diff "$PREVIOUS_REF" --name-only --diff-filter=ACMR -- "$DEPLOYMENT_PATH")
         echo all_changed_files=${CHANGED_FILES//\\n/} >> "$GITHUB_OUTPUT"
         echo deleted_files=${DELETED_FILES//\\n/} >> "$GITHUB_OUTPUT"
         echo test_files=${TEST_FILES//\\n/} >> "$GITHUB_OUTPUT"
+        echo manual_files=${MANUAL_FILES//\\n/} >> "$GITHUB_OUTPUT"
 
     - name: Run Sigma Rule Integrator
       id: integrate
@@ -116,6 +121,7 @@ runs:
         CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         DELETED_FILES: ${{ steps.changed-files.outputs.deleted_files }}
         TEST_FILES: ${{ steps.changed-files.outputs.test_files }}
+        MANUAL_FILES: ${{ steps.changed-files.outputs.manual_files }}
         ALL_RULES: ${{ inputs.all_rules }}
         CONTINUE_ON_QUERY_TESTING_ERRORS: ${{ inputs.continue_on_query_testing_errors }}
         IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
@@ -130,6 +136,7 @@ runs:
             -e CHANGED_FILES="$CHANGED_FILES" \
             -e DELETED_FILES="$DELETED_FILES" \
             -e TEST_FILES="$TEST_FILES" \
+            -e MANUAL_FILES="$MANUAL_FILES" \
             -e ALL_RULES="$ALL_RULES" \
             -e CONTINUE_ON_QUERY_TESTING_ERRORS="$CONTINUE_ON_QUERY_TESTING_ERRORS" \
             "ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:$IMAGE_REF" \

--- a/internal/integrate/integrator.go
+++ b/internal/integrate/integrator.go
@@ -139,11 +139,12 @@ func (i *Integrator) LoadConfig() error {
 	changedFiles := strings.Split(os.Getenv("CHANGED_FILES"), " ")
 	deletedFiles := strings.Split(os.Getenv("DELETED_FILES"), " ")
 	testFiles := strings.Split(os.Getenv("TEST_FILES"), " ")
+	// Deployment files a human modified since the last automation commit. These are
+	// candidates for backfilling the manual annotation before integration runs.
+	manualFiles := strings.Split(os.Getenv("MANUAL_FILES"), " ")
 
-	newUpdatedFiles := make([]string, 0, len(changedFiles))
-	removedFiles := make([]string, 0, len(deletedFiles))
-	filesToBeTested := make([]string, 0, len(testFiles))
-
+	newUpdatedFiles := []string{}
+	filesToBeTested := []string{}
 	if i.allRules {
 		if err = filepath.Walk(i.config.Folders.ConversionPath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -162,54 +163,23 @@ func (i *Integrator) LoadConfig() error {
 			return fmt.Errorf("failed to walk directory: %w", err)
 		}
 	} else {
-		for _, path := range changedFiles {
-			// Ensure paths appear within specified conversion path
-			relpath, err := filepath.Rel(i.config.Folders.ConversionPath, path)
-			if err != nil {
-				return fmt.Errorf("error checking file path %s: %v", path, err)
-			}
-			if relpath == filepath.Base(path) {
-				newUpdatedFiles = append(newUpdatedFiles, path)
-			}
+		if newUpdatedFiles, err = filterFilesInDir(changedFiles, i.config.Folders.ConversionPath); err != nil {
+			return err
 		}
 		if i.config.IntegratorConfig.TestQueries {
-			for _, path := range testFiles {
-				relpath, err := filepath.Rel(i.config.Folders.ConversionPath, path)
-				if err != nil {
-					return fmt.Errorf("error checking file path %s: %v", path, err)
-				}
-				if relpath == filepath.Base(path) {
-					filesToBeTested = append(filesToBeTested, path)
-				}
+			if filesToBeTested, err = filterFilesInDir(testFiles, i.config.Folders.ConversionPath); err != nil {
+				return err
 			}
 		}
 	}
 
-	for _, path := range deletedFiles {
-		relpath, err := filepath.Rel(i.config.Folders.ConversionPath, path)
-		if err != nil {
-			return fmt.Errorf("error checking file path %s: %v", path, err)
-		}
-		if relpath == filepath.Base(path) {
-			removedFiles = append(removedFiles, path)
-		}
+	removedFiles, err := filterFilesInDir(deletedFiles, i.config.Folders.ConversionPath)
+	if err != nil {
+		return err
 	}
-
-	// Deployment files a human modified since the last automation commit. These are
-	// candidates for backfilling the manual annotation before integration runs.
-	manualFiles := strings.Split(os.Getenv("MANUAL_FILES"), " ")
-	humanModifiedFiles := make([]string, 0, len(manualFiles))
-	for _, path := range manualFiles {
-		if path == "" {
-			continue
-		}
-		relpath, err := filepath.Rel(i.config.Folders.DeploymentPath, path)
-		if err != nil {
-			return fmt.Errorf("error checking file path %s: %v", path, err)
-		}
-		if relpath == filepath.Base(path) {
-			humanModifiedFiles = append(humanModifiedFiles, path)
-		}
+	humanModifiedFiles, err := filterFilesInDir(manualFiles, i.config.Folders.DeploymentPath)
+	if err != nil {
+		return err
 	}
 
 	fmt.Printf("Changed files: %d\nRemoved files: %d\nTest files: %d\nManual files: %d\n", len(newUpdatedFiles), len(removedFiles), len(filesToBeTested), len(humanModifiedFiles))
@@ -219,6 +189,26 @@ func (i *Integrator) LoadConfig() error {
 	i.manualFiles = humanModifiedFiles
 
 	return nil
+}
+
+// filterFilesInDir keeps only the paths that sit directly inside dir, matching a
+// diff-derived file list to a known output directory. Empty entries (e.g. from
+// splitting an unset env var) are skipped.
+func filterFilesInDir(paths []string, dir string) ([]string, error) {
+	filtered := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		relpath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return nil, fmt.Errorf("error checking file path %s: %v", path, err)
+		}
+		if relpath == filepath.Base(path) {
+			filtered = append(filtered, path)
+		}
+	}
+	return filtered, nil
 }
 
 // cleanupOrphanedFilesInPath removes orphaned files in the specified path
@@ -247,10 +237,7 @@ func (i *Integrator) cleanupOrphanedFilesInPath(searchPath string, isOrphaned fu
 		}
 
 		if orphaned {
-			if manual, mErr := isManual(file); mErr != nil {
-				fmt.Printf("Warning: could not check manual flag for %s: %v\n", file, mErr)
-			} else if manual {
-				fmt.Printf("Keeping manually-maintained orphaned file (not deleting): %s\n", file)
+			if keepAsManual(file, "orphaned") {
 				continue
 			}
 			fmt.Printf("Removing orphaned file: %s\n", file)
@@ -307,62 +294,116 @@ func (i *Integrator) isDeploymentFileOrphaned(file string) (bool, error) {
 	return false, nil
 }
 
+// manualValueSet reports whether a decoded JSON value marks a file as manual.
+// It accepts both the boolean `true` used by conversion files and the string
+// "true" used by deployment annotations, so the converter (Python) and the
+// integrator agree on what counts as manual.
+func manualValueSet(v any) bool {
+	switch val := v.(type) {
+	case bool:
+		return val
+	case string:
+		return val == TRUE
+	default:
+		return false
+	}
+}
+
 // isManual reports whether a generated file is marked as manually maintained.
 // Deployment files carry the marker as annotations["manual"] == "true"; conversion
 // files carry a top-level "manual" boolean. A single helper covers both output
 // directories so cleanup never destroys a file a human has taken ownership of.
+//
+// The file is decoded as a generic JSON document so a type mismatch on an
+// unrelated field never masks the flag, and so an unparseable file surfaces as an
+// error (callers treat that as "keep the file", never as "safe to delete").
 func isManual(file string) (bool, error) {
 	content, err := shared.ReadLocalFile(file)
 	if err != nil {
 		return false, err
 	}
 
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(content), &doc); err != nil {
+		return false, fmt.Errorf("could not parse %s as JSON: %w", file, err)
+	}
+
 	// Deployment file: manual annotation.
-	var rule model.ProvisionedAlertRule
-	if err := json.Unmarshal([]byte(content), &rule); err == nil {
-		if rule.Annotations[ManualAnnotation] == TRUE {
+	if annotations, ok := doc["annotations"].(map[string]any); ok {
+		if manualValueSet(annotations[ManualAnnotation]) {
 			return true, nil
 		}
 	}
 
-	// Conversion file: top-level manual boolean.
-	var conversion model.ConversionOutput
-	if err := json.Unmarshal([]byte(content), &conversion); err == nil {
-		if conversion.Manual {
-			return true, nil
-		}
+	// Conversion file: top-level manual flag.
+	if manualValueSet(doc[ManualAnnotation]) {
+		return true, nil
 	}
 
 	return false, nil
 }
 
+// keepAsManual reports whether a file slated for deletion must be preserved. It
+// fails closed: if the manual flag cannot be determined (unreadable/unparseable
+// file), the file is kept rather than deleted. kind labels the file in the log.
+func keepAsManual(file, kind string) bool {
+	manual, err := isManual(file)
+	if err != nil {
+		fmt.Printf("Warning: could not check manual flag for %s, keeping it: %v\n", file, err)
+		return true
+	}
+	if manual {
+		fmt.Printf("Keeping manually-maintained %s file (not deleting): %s\n", kind, file)
+		return true
+	}
+	return false
+}
+
 // BackfillManualFlags adds the manual annotation to any human-modified deployment
 // files that do not already carry it. Running before DoConversions guarantees the
 // freshly-added flag is honoured (and the file preserved) on this same run.
+//
+// The file is edited as a generic JSON document rather than round-tripped through
+// ProvisionedAlertRule, so fields the struct does not model are preserved. Any file
+// that cannot be read, parsed, or written is logged and skipped — one bad file must
+// not abort the whole integration.
 func (i *Integrator) BackfillManualFlags() error {
 	for _, file := range i.manualFiles {
-		if _, err := os.Stat(file); err != nil {
-			// The list comes from an ACMR diff so this should not happen, but never
-			// write a near-empty rule for a file that is not present.
-			fmt.Printf("Skipping manual backfill for missing file: %s\n", file)
+		content, err := shared.ReadLocalFile(file)
+		if err != nil {
+			fmt.Printf("Warning: could not read %s for manual backfill, leaving unchanged: %v\n", file, err)
 			continue
 		}
 
-		rule := &model.ProvisionedAlertRule{}
-		if err := readRuleFromFile(rule, file); err != nil {
-			return err
-		}
-		if rule.Annotations[ManualAnnotation] == TRUE {
+		var doc map[string]any
+		if err := json.Unmarshal([]byte(content), &doc); err != nil {
+			fmt.Printf("Warning: could not parse %s for manual backfill, leaving unchanged: %v\n", file, err)
 			continue
 		}
 
-		if rule.Annotations == nil {
-			rule.Annotations = make(map[string]string)
+		annotations, _ := doc["annotations"].(map[string]any)
+		// A manual key that is already present (any value) reflects a deliberate
+		// human choice; do not overwrite it.
+		if annotations != nil {
+			if _, present := annotations[ManualAnnotation]; present {
+				continue
+			}
+		} else {
+			annotations = map[string]any{}
+			doc["annotations"] = annotations
 		}
-		rule.Annotations[ManualAnnotation] = TRUE
+		annotations[ManualAnnotation] = TRUE
+
+		out, err := marshalJSON(doc, i.prettyPrint)
+		if err != nil {
+			fmt.Printf("Warning: could not marshal manual backfill for %s, leaving unchanged: %v\n", file, err)
+			continue
+		}
+
 		fmt.Printf("Marking manually-modified deployment file as manual: %s\n", file)
-		if err := writeRuleToFile(rule, file, i.prettyPrint); err != nil {
-			return err
+		if err := os.WriteFile(file, out, 0o600); err != nil {
+			fmt.Printf("Warning: could not write manual backfill for %s, leaving unchanged: %v\n", file, err)
+			continue
 		}
 	}
 	return nil
@@ -467,10 +508,7 @@ func (i *Integrator) DoCleanup() error {
 		}
 		for _, file := range deploymentFiles {
 			fullPath := i.config.Folders.DeploymentPath + string(filepath.Separator) + file
-			if manual, mErr := isManual(fullPath); mErr != nil {
-				fmt.Printf("Warning: could not check manual flag for %s: %v\n", fullPath, mErr)
-			} else if manual {
-				fmt.Printf("Keeping manually-maintained deployment file (not deleting): %s\n", fullPath)
+			if keepAsManual(fullPath, "deployment") {
 				continue
 			}
 			err = os.Remove(fullPath)
@@ -673,14 +711,17 @@ func readRuleFromFile(rule *model.ProvisionedAlertRule, inputPath string) error 
 	return nil
 }
 
-func writeRuleToFile(rule *model.ProvisionedAlertRule, outputFile string, prettyPrint bool) error {
-	var ruleBytes []byte
-	var err error
+// marshalJSON serialises v as JSON, honouring the pretty-print flag used across the
+// integrator's file writes so output formatting stays consistent in one place.
+func marshalJSON(v any, prettyPrint bool) ([]byte, error) {
 	if prettyPrint {
-		ruleBytes, err = json.MarshalIndent(rule, "", "  ")
-	} else {
-		ruleBytes, err = json.Marshal(rule)
+		return json.MarshalIndent(v, "", "  ")
 	}
+	return json.Marshal(v)
+}
+
+func writeRuleToFile(rule *model.ProvisionedAlertRule, outputFile string, prettyPrint bool) error {
+	ruleBytes, err := marshalJSON(rule, prettyPrint)
 	if err != nil {
 		return fmt.Errorf("error marshalling alert rule: %v", err)
 	}

--- a/internal/integrate/integrator.go
+++ b/internal/integrate/integrator.go
@@ -22,6 +22,11 @@ import (
 
 const TRUE = "true"
 
+// ManualAnnotation is the annotation key that marks a deployment file as
+// manually maintained. Files carrying annotations["manual"] == "true" are
+// neither overwritten nor deleted by the integrator.
+const ManualAnnotation = "manual"
+
 var FuncMap = template.FuncMap{
 	// Case conversion
 	"toUpper": strings.ToUpper,
@@ -77,6 +82,10 @@ type Integrator struct {
 	addedFiles   []string
 	removedFiles []string
 	testFiles    []string
+	// manualFiles are deployment files a human modified since the last automation
+	// commit. Any that lack the manual annotation are flagged before integration so
+	// the change is preserved on this and every future run.
+	manualFiles []string
 }
 
 func NewIntegrator() *Integrator {
@@ -186,10 +195,28 @@ func (i *Integrator) LoadConfig() error {
 		}
 	}
 
-	fmt.Printf("Changed files: %d\nRemoved files: %d\nTest files: %d\n", len(newUpdatedFiles), len(removedFiles), len(filesToBeTested))
+	// Deployment files a human modified since the last automation commit. These are
+	// candidates for backfilling the manual annotation before integration runs.
+	manualFiles := strings.Split(os.Getenv("MANUAL_FILES"), " ")
+	humanModifiedFiles := make([]string, 0, len(manualFiles))
+	for _, path := range manualFiles {
+		if path == "" {
+			continue
+		}
+		relpath, err := filepath.Rel(i.config.Folders.DeploymentPath, path)
+		if err != nil {
+			return fmt.Errorf("error checking file path %s: %v", path, err)
+		}
+		if relpath == filepath.Base(path) {
+			humanModifiedFiles = append(humanModifiedFiles, path)
+		}
+	}
+
+	fmt.Printf("Changed files: %d\nRemoved files: %d\nTest files: %d\nManual files: %d\n", len(newUpdatedFiles), len(removedFiles), len(filesToBeTested), len(humanModifiedFiles))
 	i.addedFiles = newUpdatedFiles
 	i.removedFiles = removedFiles
 	i.testFiles = filesToBeTested
+	i.manualFiles = humanModifiedFiles
 
 	return nil
 }
@@ -220,6 +247,12 @@ func (i *Integrator) cleanupOrphanedFilesInPath(searchPath string, isOrphaned fu
 		}
 
 		if orphaned {
+			if manual, mErr := isManual(file); mErr != nil {
+				fmt.Printf("Warning: could not check manual flag for %s: %v\n", file, mErr)
+			} else if manual {
+				fmt.Printf("Keeping manually-maintained orphaned file (not deleting): %s\n", file)
+				continue
+			}
 			fmt.Printf("Removing orphaned file: %s\n", file)
 			if err := os.Remove(file); err != nil {
 				fmt.Printf("Warning: Could not remove orphaned file %s: %v\n", file, err)
@@ -274,7 +307,74 @@ func (i *Integrator) isDeploymentFileOrphaned(file string) (bool, error) {
 	return false, nil
 }
 
+// isManual reports whether a generated file is marked as manually maintained.
+// Deployment files carry the marker as annotations["manual"] == "true"; conversion
+// files carry a top-level "manual" boolean. A single helper covers both output
+// directories so cleanup never destroys a file a human has taken ownership of.
+func isManual(file string) (bool, error) {
+	content, err := shared.ReadLocalFile(file)
+	if err != nil {
+		return false, err
+	}
+
+	// Deployment file: manual annotation.
+	var rule model.ProvisionedAlertRule
+	if err := json.Unmarshal([]byte(content), &rule); err == nil {
+		if rule.Annotations[ManualAnnotation] == TRUE {
+			return true, nil
+		}
+	}
+
+	// Conversion file: top-level manual boolean.
+	var conversion model.ConversionOutput
+	if err := json.Unmarshal([]byte(content), &conversion); err == nil {
+		if conversion.Manual {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// BackfillManualFlags adds the manual annotation to any human-modified deployment
+// files that do not already carry it. Running before DoConversions guarantees the
+// freshly-added flag is honoured (and the file preserved) on this same run.
+func (i *Integrator) BackfillManualFlags() error {
+	for _, file := range i.manualFiles {
+		if _, err := os.Stat(file); err != nil {
+			// The list comes from an ACMR diff so this should not happen, but never
+			// write a near-empty rule for a file that is not present.
+			fmt.Printf("Skipping manual backfill for missing file: %s\n", file)
+			continue
+		}
+
+		rule := &model.ProvisionedAlertRule{}
+		if err := readRuleFromFile(rule, file); err != nil {
+			return err
+		}
+		if rule.Annotations[ManualAnnotation] == TRUE {
+			continue
+		}
+
+		if rule.Annotations == nil {
+			rule.Annotations = make(map[string]string)
+		}
+		rule.Annotations[ManualAnnotation] = TRUE
+		fmt.Printf("Marking manually-modified deployment file as manual: %s\n", file)
+		if err := writeRuleToFile(rule, file, i.prettyPrint); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (i *Integrator) Run() error {
+	// Preserve any deployment files a human modified by flagging them as manual
+	// before we integrate, so their changes are not overwritten on this run.
+	if err := i.BackfillManualFlags(); err != nil {
+		return err
+	}
+
 	// Convert all files that have been updated from the last commit
 	if err := i.DoConversions(); err != nil {
 		return err
@@ -340,6 +440,10 @@ func (i *Integrator) DoConversions() error {
 		if err != nil {
 			return err
 		}
+		if rule.Annotations[ManualAnnotation] == TRUE {
+			fmt.Printf("Skipping manually-maintained deployment file (not overwriting): %s\n", file)
+			continue
+		}
 		err = i.ConvertToAlert(rule, queries, titles, config, inputFile, conversionObject)
 		if err != nil {
 			return err
@@ -362,7 +466,14 @@ func (i *Integrator) DoCleanup() error {
 			return fmt.Errorf("error when searching for deployment files for %s: %v", deletedFile, err)
 		}
 		for _, file := range deploymentFiles {
-			err = os.Remove(i.config.Folders.DeploymentPath + string(filepath.Separator) + file)
+			fullPath := i.config.Folders.DeploymentPath + string(filepath.Separator) + file
+			if manual, mErr := isManual(fullPath); mErr != nil {
+				fmt.Printf("Warning: could not check manual flag for %s: %v\n", fullPath, mErr)
+			} else if manual {
+				fmt.Printf("Keeping manually-maintained deployment file (not deleting): %s\n", fullPath)
+				continue
+			}
+			err = os.Remove(fullPath)
 			if err != nil {
 				return fmt.Errorf("error when deleting deployment file %s: %v", file, err)
 			}

--- a/internal/integrate/manual_test.go
+++ b/internal/integrate/manual_test.go
@@ -1,0 +1,209 @@
+package integrate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/sigma-rule-deployment/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// manualTestDirs creates fresh relative conversion and deployment directories for
+// a test. Relative paths are required because shared.ReadLocalFile rejects
+// absolute paths (so t.TempDir cannot be used here).
+func manualTestDirs(t *testing.T, name string) (convPath, deployPath string) {
+	t.Helper()
+	base := filepath.Join("testdata", "test_manual", name)
+	assert.NoError(t, os.RemoveAll(base))
+	convPath = filepath.Join(base, "conv")
+	deployPath = filepath.Join(base, "deploy")
+	assert.NoError(t, os.MkdirAll(convPath, 0o755))
+	assert.NoError(t, os.MkdirAll(deployPath, 0o755))
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	return convPath, deployPath
+}
+
+// TestBackfillManualFlags checks that human-modified deployment files gain the
+// manual annotation while their content is preserved, and that files already
+// flagged are left untouched.
+func TestBackfillManualFlags(t *testing.T) {
+	_, deployDir := manualTestDirs(t, "backfill")
+
+	// A deployment file a human edited but did not flag.
+	unflaggedPath := filepath.Join(deployDir, "alert_rule_conv_rule_abc123.json")
+	unflagged := &model.ProvisionedAlertRule{
+		UID:       "abc123",
+		Title:     "Hand edited title",
+		RuleGroup: "Test Rules",
+		Annotations: map[string]string{
+			"Query": "custom query",
+		},
+	}
+	assert.NoError(t, writeRuleToFile(unflagged, unflaggedPath, false))
+
+	// A deployment file that is already flagged manual.
+	flaggedPath := filepath.Join(deployDir, "alert_rule_conv_rule_def456.json")
+	flagged := &model.ProvisionedAlertRule{
+		UID:         "def456",
+		Title:       "Already manual",
+		Annotations: map[string]string{ManualAnnotation: TRUE},
+	}
+	assert.NoError(t, writeRuleToFile(flagged, flaggedPath, false))
+	flaggedBefore, err := os.ReadFile(flaggedPath)
+	assert.NoError(t, err)
+
+	i := &Integrator{
+		config:      model.Configuration{Folders: model.FoldersConfig{DeploymentPath: deployDir}},
+		manualFiles: []string{unflaggedPath, flaggedPath},
+	}
+	assert.NoError(t, i.BackfillManualFlags())
+
+	// The unflagged file gains the manual annotation while keeping its content.
+	got := &model.ProvisionedAlertRule{}
+	assert.NoError(t, readRuleFromFile(got, unflaggedPath))
+	assert.Equal(t, TRUE, got.Annotations[ManualAnnotation])
+	assert.Equal(t, "Hand edited title", got.Title)
+	assert.Equal(t, "custom query", got.Annotations["Query"])
+
+	// The already-flagged file is left byte-for-byte unchanged.
+	flaggedAfter, err := os.ReadFile(flaggedPath)
+	assert.NoError(t, err)
+	assert.Equal(t, flaggedBefore, flaggedAfter)
+}
+
+// TestDoConversionsSkipsManualDeployment checks that a deployment file marked
+// manual is not overwritten even when its source conversion changes.
+func TestDoConversionsSkipsManualDeployment(t *testing.T) {
+	convPath, deployPath := manualTestDirs(t, "skip_overwrite")
+
+	config := model.Configuration{
+		Folders:            model.FoldersConfig{ConversionPath: convPath, DeploymentPath: deployPath},
+		ConversionDefaults: model.ConversionConfig{Target: "loki", DataSource: "test-datasource"},
+		Conversions:        []model.ConversionConfig{{Name: "test_conv", RuleGroup: "Test Rules", TimeWindow: "5m"}},
+		IntegratorConfig:   model.IntegrationConfig{FolderID: "test-folder", OrgID: 1},
+	}
+
+	convOutput := model.ConversionOutput{
+		ConversionName: "test_conv",
+		Queries:        []string{"{job=`test`} | json"},
+		Rules:          []model.SigmaRule{{ID: "996f8884-9144-40e7-ac63-29090ccde9a0", Title: "Test Rule"}},
+	}
+	convFile := filepath.Join(convPath, "test_conv.json")
+	writeConversion := func(o model.ConversionOutput) {
+		b, mErr := json.Marshal(o)
+		assert.NoError(t, mErr)
+		assert.NoError(t, os.WriteFile(convFile, b, 0o600))
+	}
+	writeConversion(convOutput)
+
+	// First pass generates the deployment file.
+	i := &Integrator{config: config, addedFiles: []string{convFile}}
+	assert.NoError(t, i.DoConversions())
+
+	deployFiles, err := filepath.Glob(filepath.Join(deployPath, "alert_rule_*.json"))
+	assert.NoError(t, err)
+	assert.Len(t, deployFiles, 1)
+	deployFile := deployFiles[0]
+
+	// Human takes ownership: flag it manual and change the title.
+	rule := &model.ProvisionedAlertRule{}
+	assert.NoError(t, readRuleFromFile(rule, deployFile))
+	if rule.Annotations == nil {
+		rule.Annotations = map[string]string{}
+	}
+	rule.Annotations[ManualAnnotation] = TRUE
+	rule.Title = "HAND EDITED"
+	assert.NoError(t, writeRuleToFile(rule, deployFile, false))
+
+	// Change the conversion so a real run would overwrite the rule (the UID, and
+	// therefore the deployment path, is derived from rule identity, not the query).
+	convOutput.Queries = []string{"{job=`changed`} | json"}
+	writeConversion(convOutput)
+
+	// Second pass must not overwrite the manual file.
+	i = &Integrator{config: config, addedFiles: []string{convFile}}
+	assert.NoError(t, i.DoConversions())
+
+	got := &model.ProvisionedAlertRule{}
+	assert.NoError(t, readRuleFromFile(got, deployFile))
+	assert.Equal(t, "HAND EDITED", got.Title)
+	assert.Equal(t, TRUE, got.Annotations[ManualAnnotation])
+}
+
+// TestDoCleanupPreservesManual checks that manual deployment files survive both
+// the deleted-rule cleanup and the orphaned-file cleanup.
+func TestDoCleanupPreservesManual(t *testing.T) {
+	newConfig := func(convPath, deployPath string) model.Configuration {
+		return model.Configuration{
+			Folders:     model.FoldersConfig{ConversionPath: convPath, DeploymentPath: deployPath},
+			Conversions: []model.ConversionConfig{{Name: "test_conv"}},
+		}
+	}
+
+	t.Run("deleted rule keeps manual deployment file", func(t *testing.T) {
+		convPath, deployPath := manualTestDirs(t, "cleanup_deleted")
+
+		deployFile := filepath.Join(deployPath, "alert_rule_test_conv_test_123abc.json")
+		rule := &model.ProvisionedAlertRule{UID: "123abc", Title: "Manual", Annotations: map[string]string{ManualAnnotation: TRUE}}
+		assert.NoError(t, writeRuleToFile(rule, deployFile, false))
+
+		i := &Integrator{config: newConfig(convPath, deployPath), removedFiles: []string{filepath.Join(convPath, "test_conv.json")}}
+		assert.NoError(t, i.DoCleanup())
+
+		_, err := os.Stat(deployFile)
+		assert.NoError(t, err, "manual deployment file should be preserved")
+	})
+
+	t.Run("orphaned manual deployment file is kept", func(t *testing.T) {
+		convPath, deployPath := manualTestDirs(t, "cleanup_orphan")
+
+		orphan := filepath.Join(deployPath, "alert_rule_orphan_deploy_456def.json")
+		rule := &model.ProvisionedAlertRule{
+			UID:   "456def",
+			Title: "Orphan Manual",
+			Annotations: map[string]string{
+				ManualAnnotation: TRUE,
+				"ConversionFile": "/path/does/not/exist.json",
+			},
+		}
+		assert.NoError(t, writeRuleToFile(rule, orphan, false))
+
+		i := &Integrator{config: newConfig(convPath, deployPath)}
+		assert.NoError(t, i.DoCleanup())
+
+		_, err := os.Stat(orphan)
+		assert.NoError(t, err, "orphaned manual deployment file should be preserved")
+	})
+}
+
+// TestIsManual checks that the shared manual-detection helper recognises the flag
+// on both deployment files (annotation) and conversion files (top-level boolean).
+func TestIsManual(t *testing.T) {
+	_, dir := manualTestDirs(t, "is_manual")
+
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		assert.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+		return p
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"manual deployment", write("manual_deploy.json", `{"uid":"x","annotations":{"manual":"true"}}`), true},
+		{"plain deployment", write("plain_deploy.json", `{"uid":"x","annotations":{"Query":"q"}}`), false},
+		{"manual conversion", write("manual_conv.json", `{"conversion_name":"c","manual":true}`), true},
+		{"plain conversion", write("plain_conv.json", `{"conversion_name":"c","queries":["q"]}`), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := isManual(tc.path)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/integrate/manual_test.go
+++ b/internal/integrate/manual_test.go
@@ -227,6 +227,67 @@ func TestBackfillManualFlagsRespectsExplicitFalse(t *testing.T) {
 	assert.Equal(t, before, after, "explicit manual:false must not be re-flagged")
 }
 
+// TestDoConversionsRegeneratesManualFalseDeployment checks the opt-out path: a
+// deployment file whose manual annotation is set to "false" is not re-flagged by
+// the backfill and is regenerated (not skipped) when its conversion changes.
+func TestDoConversionsRegeneratesManualFalseDeployment(t *testing.T) {
+	convPath, deployPath := manualTestDirs(t, "false_regen")
+
+	config := model.Configuration{
+		Folders:            model.FoldersConfig{ConversionPath: convPath, DeploymentPath: deployPath},
+		ConversionDefaults: model.ConversionConfig{Target: "loki", DataSource: "test-datasource"},
+		Conversions:        []model.ConversionConfig{{Name: "test_conv", RuleGroup: "Test Rules", TimeWindow: "5m"}},
+		IntegratorConfig:   model.IntegrationConfig{FolderID: "test-folder", OrgID: 1},
+	}
+
+	convOutput := model.ConversionOutput{
+		ConversionName: "test_conv",
+		Queries:        []string{"{job=`test`} | json"},
+		Rules:          []model.SigmaRule{{ID: "996f8884-9144-40e7-ac63-29090ccde9a0", Title: "Test Rule"}},
+	}
+	convFile := filepath.Join(convPath, "test_conv.json")
+	writeConversion := func(o model.ConversionOutput) {
+		b, mErr := json.Marshal(o)
+		assert.NoError(t, mErr)
+		assert.NoError(t, os.WriteFile(convFile, b, 0o600))
+	}
+	writeConversion(convOutput)
+
+	// First pass generates the deployment file.
+	i := &Integrator{config: config, addedFiles: []string{convFile}}
+	assert.NoError(t, i.DoConversions())
+
+	deployFiles, err := filepath.Glob(filepath.Join(deployPath, "alert_rule_*.json"))
+	assert.NoError(t, err)
+	assert.Len(t, deployFiles, 1)
+	deployFile := deployFiles[0]
+
+	// Human hands the file back: set the annotation to "false" and leave a stale title.
+	rule := &model.ProvisionedAlertRule{}
+	assert.NoError(t, readRuleFromFile(rule, deployFile))
+	if rule.Annotations == nil {
+		rule.Annotations = map[string]string{}
+	}
+	rule.Annotations[ManualAnnotation] = "false"
+	rule.Title = "STALE"
+	assert.NoError(t, writeRuleToFile(rule, deployFile, false))
+
+	// Change the conversion, and present the file as human-modified (as the diff would).
+	convOutput.Queries = []string{"{job=`changed`} | json"}
+	writeConversion(convOutput)
+
+	i = &Integrator{config: config, addedFiles: []string{convFile}, manualFiles: []string{deployFile}}
+	assert.NoError(t, i.BackfillManualFlags())
+	assert.NoError(t, i.DoConversions())
+
+	got := &model.ProvisionedAlertRule{}
+	assert.NoError(t, readRuleFromFile(got, deployFile))
+	// The backfill left the "false" flag alone (did not re-add "true")...
+	assert.Equal(t, "false", got.Annotations[ManualAnnotation])
+	// ...and the false flag did not block regeneration.
+	assert.NotEqual(t, "STALE", got.Title)
+}
+
 // TestIsManualMalformedReturnsError checks that unparseable files surface an error
 // (so callers can fail closed) rather than being silently treated as non-manual.
 func TestIsManualMalformedReturnsError(t *testing.T) {

--- a/internal/integrate/manual_test.go
+++ b/internal/integrate/manual_test.go
@@ -178,6 +178,84 @@ func TestDoCleanupPreservesManual(t *testing.T) {
 	})
 }
 
+// TestBackfillManualFlagsPreservesUnmodeledFields checks that backfilling the flag
+// does not drop JSON fields the ProvisionedAlertRule struct does not model.
+func TestBackfillManualFlagsPreservesUnmodeledFields(t *testing.T) {
+	_, deployDir := manualTestDirs(t, "backfill_preserve")
+	path := filepath.Join(deployDir, "alert_rule_conv_rule_zzz.json")
+	// Raw JSON carrying a field the struct does not model, and annotations without the flag.
+	raw := `{"uid":"zzz","title":"Keep me","customField":"keepme","annotations":{"Query":"q"}}`
+	assert.NoError(t, os.WriteFile(path, []byte(raw), 0o600))
+
+	i := &Integrator{
+		config:      model.Configuration{Folders: model.FoldersConfig{DeploymentPath: deployDir}},
+		manualFiles: []string{path},
+	}
+	assert.NoError(t, i.BackfillManualFlags())
+
+	content, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	var doc map[string]any
+	assert.NoError(t, json.Unmarshal(content, &doc))
+
+	// The unmodeled field and existing content survive; the flag is added.
+	assert.Equal(t, "keepme", doc["customField"])
+	assert.Equal(t, "Keep me", doc["title"])
+	annotations, ok := doc["annotations"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, TRUE, annotations[ManualAnnotation])
+	assert.Equal(t, "q", annotations["Query"])
+}
+
+// TestBackfillManualFlagsRespectsExplicitFalse checks that a deliberately-set
+// manual value is never overwritten by the backfill.
+func TestBackfillManualFlagsRespectsExplicitFalse(t *testing.T) {
+	_, deployDir := manualTestDirs(t, "backfill_false")
+	path := filepath.Join(deployDir, "alert_rule_conv_rule_fff.json")
+	assert.NoError(t, os.WriteFile(path, []byte(`{"uid":"fff","annotations":{"manual":"false"}}`), 0o600))
+	before, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	i := &Integrator{
+		config:      model.Configuration{Folders: model.FoldersConfig{DeploymentPath: deployDir}},
+		manualFiles: []string{path},
+	}
+	assert.NoError(t, i.BackfillManualFlags())
+
+	after, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	assert.Equal(t, before, after, "explicit manual:false must not be re-flagged")
+}
+
+// TestIsManualMalformedReturnsError checks that unparseable files surface an error
+// (so callers can fail closed) rather than being silently treated as non-manual.
+func TestIsManualMalformedReturnsError(t *testing.T) {
+	_, dir := manualTestDirs(t, "is_manual_malformed")
+	path := filepath.Join(dir, "broken.json")
+	assert.NoError(t, os.WriteFile(path, []byte(`{"uid":"x", broken`), 0o600))
+
+	_, err := isManual(path)
+	assert.Error(t, err)
+}
+
+// TestDoCleanupKeepsUnparseableFile checks that cleanup fails closed: a file it
+// cannot classify is kept, not deleted.
+func TestDoCleanupKeepsUnparseableFile(t *testing.T) {
+	convPath, deployPath := manualTestDirs(t, "cleanup_malformed")
+	deployFile := filepath.Join(deployPath, "alert_rule_test_conv_test_999zzz.json")
+	assert.NoError(t, os.WriteFile(deployFile, []byte(`{ broken json`), 0o600))
+
+	config := model.Configuration{
+		Folders:     model.FoldersConfig{ConversionPath: convPath, DeploymentPath: deployPath},
+		Conversions: []model.ConversionConfig{{Name: "test_conv"}},
+	}
+	i := &Integrator{config: config, removedFiles: []string{filepath.Join(convPath, "test_conv.json")}}
+	assert.NoError(t, i.DoCleanup())
+
+	_, err := os.Stat(deployFile)
+	assert.NoError(t, err, "unparseable file must be kept (fail closed), not deleted")
+}
+
 // TestIsManual checks that the shared manual-detection helper recognises the flag
 // on both deployment files (annotation) and conversion files (top-level boolean).
 func TestIsManual(t *testing.T) {
@@ -195,8 +273,10 @@ func TestIsManual(t *testing.T) {
 		want bool
 	}{
 		{"manual deployment", write("manual_deploy.json", `{"uid":"x","annotations":{"manual":"true"}}`), true},
+		{"false deployment", write("false_deploy.json", `{"uid":"x","annotations":{"manual":"false"}}`), false},
 		{"plain deployment", write("plain_deploy.json", `{"uid":"x","annotations":{"Query":"q"}}`), false},
-		{"manual conversion", write("manual_conv.json", `{"conversion_name":"c","manual":true}`), true},
+		{"manual conversion (bool)", write("manual_conv.json", `{"conversion_name":"c","manual":true}`), true},
+		{"manual conversion (string)", write("manual_conv_str.json", `{"conversion_name":"c","manual":"true"}`), true},
 		{"plain conversion", write("plain_conv.json", `{"conversion_name":"c","queries":["q"]}`), false},
 	}
 	for _, tc := range cases {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -43,9 +43,6 @@ type ConversionOutput struct {
 	InputFile      string      `json:"input_file"`
 	Rules          []SigmaRule `json:"rules"`
 	OutputFile     string      `json:"output_file"`
-	// Manual, when true, marks this conversion file as manually maintained.
-	// The converter will not overwrite or delete files carrying this flag.
-	Manual bool `json:"manual,omitempty"`
 }
 
 // MetricValue represents a value with its unit

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -43,6 +43,9 @@ type ConversionOutput struct {
 	InputFile      string      `json:"input_file"`
 	Rules          []SigmaRule `json:"rules"`
 	OutputFile     string      `json:"output_file"`
+	// Manual, when true, marks this conversion file as manually maintained.
+	// The converter will not overwrite or delete files carrying this flag.
+	Manual bool `json:"manual,omitempty"`
 }
 
 // MetricValue represents a value with its unit


### PR DESCRIPTION
This change prevents the SRD conversion and integration actions from silently overwriting or deleting generated files that a human has hand-edited.

A manual flag now marks a generated file as manually maintained — a top-level `"manual": true` on conversion files, and a `"manual": "true"` annotation on deployment (alert rule) files, so the alert-rule schema stays valid. Once a file carries the flag, neither the converter nor the integrator will regenerate it, and neither will delete it — including when its source rule is removed or the file would otherwise be cleaned up as an orphan.

Because people forget to add the flag, the tools also backfill it automatically. Each action diffs its output directory against the last automation commit (reusing the existing previous-ref machinery) and passes any human-touched files to the tool via a new `MANUAL_FILES` input. The converter and integrator flag those files before generating, so an edit is preserved on the same run and every run after. To allow the automation to update it again, set `"manual": false`.

The work spans the Go integrator, the Python converter, and both composite action wrappers, and is covered by new unit tests on both sides plus documentation in the getting-started guide and both action READMEs. Surfacing a review diff of the skipped change in the PR comment is deliberately left to a follow-up PR.