### PR TITLE
Use rule titles in deployment comments

### DIFF
--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -105,43 +105,25 @@ runs:
         ALERTS_CREATED: ${{ steps.output.outputs.alerts_created }}
         ALERTS_UPDATED: ${{ steps.output.outputs.alerts_updated }}
         ALERTS_DELETED: ${{ steps.output.outputs.alerts_deleted }}
+        ALERTS_CREATED_DETAILS: ${{ steps.output.outputs.alerts_created_details }}
+        ALERTS_UPDATED_DETAILS: ${{ steps.output.outputs.alerts_updated_details }}
+        ALERTS_DELETED_DETAILS: ${{ steps.output.outputs.alerts_deleted_details }}
         GRAFANA_INSTANCE: ${{ steps.grafana-instance.outputs.grafana_instance }}
+        ACTION_PATH: ${{ github.action_path }}
       with:
           script: |
-            const url = process.env.GRAFANA_INSTANCE.replaceAll("\"", "");
+            const { buildDeploymentComment, parseDeploymentResults } = require(`${process.env.ACTION_PATH}/deployment-comment.cjs`);
 
-            const createdUids = process.env.ALERTS_CREATED.split(" ").filter(uid => uid !== "");
-            const updatedUids = process.env.ALERTS_UPDATED.split(" ").filter(uid => uid !== "");
-            const deletedUids = process.env.ALERTS_DELETED.split(" ").filter(uid => uid !== "");
+            const createdAlerts = parseDeploymentResults(process.env.ALERTS_CREATED_DETAILS, process.env.ALERTS_CREATED);
+            const updatedAlerts = parseDeploymentResults(process.env.ALERTS_UPDATED_DETAILS, process.env.ALERTS_UPDATED);
+            const deletedAlerts = parseDeploymentResults(process.env.ALERTS_DELETED_DETAILS, process.env.ALERTS_DELETED);
 
-            let createdUrls = [];
-            let updatedUrls = [];
-
-            if (url) {
-              createdUrls = createdUids.map(uid => `${url}/alerting/grafana/${uid}/view`);
-              updatedUrls = updatedUids.map(uid => `${url}/alerting/grafana/${uid}/view`);
-            }
-
-            const body = `
-            ## Sigma Rule Deployment Status
-
-            | Created | Updated | Deleted |
-            | --- | --- | --- |
-            | ${createdUids.length} | ${updatedUids.length} | ${deletedUids.length} |
-
-            ### Created
-
-            ${createdUrls.length === createdUids.length ? createdUrls.map((url, index) => `- [${createdUids[index]}](${url})`).join("\n") : createdUids.map(uid => `- ${uid}`).join("\n")}
-
-            ### Updated
-
-            ${updatedUrls.length === updatedUids.length ? updatedUrls.map((url, index) => `- [${updatedUids[index]}](${url})`).join("\n") : updatedUids.map(uid => `- ${uid}`).join("\n")}
-
-            ### Deleted
-
-            ${deletedUids.map(uid => `- ${uid}`).join("\n")}
-
-            `;
+            const body = buildDeploymentComment({
+              created: createdAlerts,
+              updated: updatedAlerts,
+              deleted: deletedAlerts,
+              grafanaInstance: process.env.GRAFANA_INSTANCE,
+            });
 
             const associatedPrs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,

--- a/actions/deploy/deployment-comment.cjs
+++ b/actions/deploy/deployment-comment.cjs
@@ -1,0 +1,93 @@
+'use strict';
+
+const titleCollator = new Intl.Collator('en', {
+  numeric: true,
+  sensitivity: 'base',
+});
+
+function normalizeDeploymentResults(results) {
+  if (!Array.isArray(results)) {
+    return [];
+  }
+
+  return results
+    .filter((result) => result && typeof result.uid === 'string' && result.uid.trim() !== '')
+    .map((result) => {
+      const uid = result.uid.trim();
+      const title =
+        typeof result.title === 'string' && result.title.trim() !== '' ? result.title.trim() : uid;
+      return { uid, title };
+    })
+    .sort(
+      (first, second) =>
+        titleCollator.compare(first.title, second.title) ||
+        titleCollator.compare(first.uid, second.uid)
+    );
+}
+
+function parseDeploymentResults(details, uidList = '') {
+  let parsed = [];
+  try {
+    parsed = JSON.parse(details || '[]');
+  } catch {
+    parsed = [];
+  }
+
+  if (Array.isArray(parsed) && parsed.length > 0) {
+    return normalizeDeploymentResults(parsed);
+  }
+
+  const fallback = String(uidList || '')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((uid) => ({ uid, title: uid }));
+
+  return normalizeDeploymentResults(fallback);
+}
+
+function renderAlertList(alerts, grafanaInstance, includeLinks) {
+  const baseUrl = String(grafanaInstance || '')
+    .replaceAll('"', '')
+    .replace(/\/+$/, '');
+
+  return normalizeDeploymentResults(alerts)
+    .map(({ uid, title }) => {
+      if (includeLinks && baseUrl) {
+        return `- [${title}](${baseUrl}/alerting/grafana/${encodeURIComponent(uid)}/view)`;
+      }
+      return `- ${title}`;
+    })
+    .join('\n');
+}
+
+function buildDeploymentComment({ created = [], updated = [], deleted = [], grafanaInstance = '' }) {
+  const createdAlerts = normalizeDeploymentResults(created);
+  const updatedAlerts = normalizeDeploymentResults(updated);
+  const deletedAlerts = normalizeDeploymentResults(deleted);
+
+  return `
+## Sigma Rule Deployment Status
+
+| Created | Updated | Deleted |
+| --- | --- | --- |
+| ${createdAlerts.length} | ${updatedAlerts.length} | ${deletedAlerts.length} |
+
+### Created
+
+${renderAlertList(createdAlerts, grafanaInstance, true)}
+
+### Updated
+
+${renderAlertList(updatedAlerts, grafanaInstance, true)}
+
+### Deleted
+
+${renderAlertList(deletedAlerts, grafanaInstance, false)}
+`;
+}
+
+module.exports = {
+  buildDeploymentComment,
+  normalizeDeploymentResults,
+  parseDeploymentResults,
+};

--- a/internal/deploy/deployer.go
+++ b/internal/deploy/deployer.go
@@ -112,20 +112,16 @@ func (d *Deployer) Deploy(ctx context.Context) ([]AlertDeployment, []AlertDeploy
 			log.Printf("Can't read file %s: %v", alertFile, err)
 			return alertsCreated, alertsUpdated, alertsDeleted, err
 		}
-		alert, err := parseAlert(content)
-		if err != nil {
-			return alertsCreated, alertsUpdated, alertsDeleted, err
-		}
-		uid, updated, err := d.createAlert(ctx, content, true)
+		deployment, updated, err := d.createAlert(ctx, content, true)
 		if err != nil {
 			return alertsCreated, alertsUpdated, alertsDeleted, err
 		}
 		if updated {
 			// If the alert was updated, we need to add it to the list of updated alerts
-			alertsUpdated = append(alertsUpdated, AlertDeployment{UID: uid, Title: alert.Title})
+			alertsUpdated = append(alertsUpdated, deployment)
 		} else {
 			// If the alert was created, we need to add it to the list of created alerts
-			alertsCreated = append(alertsCreated, AlertDeployment{UID: uid, Title: alert.Title})
+			alertsCreated = append(alertsCreated, deployment)
 		}
 	}
 	// Process alert UPDATES
@@ -135,11 +131,7 @@ func (d *Deployer) Deploy(ctx context.Context) ([]AlertDeployment, []AlertDeploy
 			log.Printf("Can't read file %s: %v", alertFile, err)
 			return alertsCreated, alertsUpdated, alertsDeleted, err
 		}
-		alert, err := parseAlert(content)
-		if err != nil {
-			return alertsCreated, alertsUpdated, alertsDeleted, err
-		}
-		uid, created, err := d.updateAlert(ctx, content, true)
+		deployment, created, err := d.updateAlert(ctx, content, true)
 		if err != nil {
 			return alertsCreated, alertsUpdated, alertsDeleted, err
 		}
@@ -148,10 +140,10 @@ func (d *Deployer) Deploy(ctx context.Context) ([]AlertDeployment, []AlertDeploy
 		// So we take this into account for the reporting
 		if created {
 			// If the alert was created, we need to add it to the list of created alerts
-			alertsCreated = append(alertsCreated, AlertDeployment{UID: uid, Title: alert.Title})
+			alertsCreated = append(alertsCreated, deployment)
 		} else {
 			// If the alert was updated, we need to add it to the list of updated alerts
-			alertsUpdated = append(alertsUpdated, AlertDeployment{UID: uid, Title: alert.Title})
+			alertsUpdated = append(alertsUpdated, deployment)
 		}
 	}
 
@@ -363,9 +355,9 @@ func addToAlertList(alertList []string, file string, prefix string) []string {
 	return alertList
 }
 
-func (d *Deployer) createAlert(ctx context.Context, content string, updateIfExists bool) (string, bool, error) {
+func (d *Deployer) createAlert(ctx context.Context, content string, updateIfExists bool) (AlertDeployment, bool, error) {
 	//  Return values:
-	// 1. UID of the alert
+	// 1. Deployment details of the alert
 	// 2. Whether the alert was updated instead of create. If updateIfExists is false, this will always be false.
 	// 3. Error if any
 
@@ -377,92 +369,94 @@ func (d *Deployer) createAlert(ctx context.Context, content string, updateIfExis
 	// Retrieve some alert information
 	alert, err := parseAlert(content)
 	if err != nil {
-		return "", false, err
+		return AlertDeployment{}, false, err
 	}
+	deployment := AlertDeployment{UID: alert.UID, Title: alert.Title}
 	d.groupsToUpdate[alert.RuleGroup] = true
 
 	// Prepare the request
 	res, err := d.client.PostRaw(ctx, "api/v1/provisioning/alert-rules", []byte(content))
 	if err != nil {
-		return "", false, err
+		return AlertDeployment{}, false, err
 	}
 	defer res.Body.Close()
 
 	// Check the response
 	resp := Response{}
 	if err := shared.ReadJSONResponse(res, &resp); err != nil {
-		return "", false, err
+		return AlertDeployment{}, false, err
 	}
 
 	switch res.StatusCode {
 	case http.StatusCreated:
 		// Alert created successfully
 		log.Printf("Alert %s (%s) created", alert.UID, alert.Title)
-		return alert.UID, false, nil
+		return deployment, false, nil
 	case http.StatusConflict:
 		// Another alert with the same UID exists
 		// If the alert already exists and we don't want to update it, we return an error
 		if !updateIfExists {
 			log.Printf("Alert %s (%s) conflicts with another alert", alert.UID, alert.Title)
-			return "", false, fmt.Errorf("error creating alert: returned status %s", res.Status)
+			return AlertDeployment{}, false, fmt.Errorf("error creating alert: returned status %s", res.Status)
 		}
 		// Otherwise, we need to check if it's a re-creation (in which case we proceed to update it instead)
 		// or an actual conflict
-		uid, err := d.tryToUpdateConflictingAlert(ctx, alert, content)
+		updatedDeployment, err := d.tryToUpdateConflictingAlert(ctx, alert, content)
 		if err != nil {
-			return "", false, err
+			return AlertDeployment{}, false, err
 		}
 
-		return uid, true, nil
+		return updatedDeployment, true, nil
 	default:
 		log.Printf("Can't create alert %s (%s). Status: %d, Message: %s", alert.UID, alert.Title, res.StatusCode, resp.Message)
-		return "", false, fmt.Errorf("error creating alert: returned status %s", res.Status)
+		return AlertDeployment{}, false, fmt.Errorf("error creating alert: returned status %s", res.Status)
 	}
 }
 
-func (d *Deployer) tryToUpdateConflictingAlert(ctx context.Context, alert model.Alert, content string) (string, error) {
+func (d *Deployer) tryToUpdateConflictingAlert(ctx context.Context, alert model.Alert, content string) (AlertDeployment, error) {
 	// Retrieve the existing alert it's conflicting with
 	existingAlert, err := d.getAlert(ctx, alert.UID)
 	if err != nil {
 		log.Printf("Can't get alert %s. Error: %v", alert.UID, err)
-		return "", fmt.Errorf("error getting alert: %v", err)
+		return AlertDeployment{}, fmt.Errorf("error getting alert: %v", err)
 	}
 	// Check if the conflicting alerts have the same parameters
 	// Otherwise, it's an actual conflict
 	if !d.checkAlertsMatch(existingAlert, alert) {
 		// The alert already exists, but with different parameters
 		log.Printf("Alert %s (%s) is conflicting with another alert having the same UID", alert.UID, alert.Title)
-		return "", fmt.Errorf("error creating alert: %v", err)
+		return AlertDeployment{}, fmt.Errorf("error creating alert: %v", err)
 	}
 	// The alert already exists, but with the same parameters
 	// In this case, we can proceed to update it
 	log.Printf("Alert %s (%s) already exists, updating it instead", alert.UID, alert.Title)
-	uid, _, err := d.updateAlert(ctx, content, false)
+	deployment, _, err := d.updateAlert(ctx, content, false)
 	if err != nil {
 		log.Printf("Can't update alert %s: %v", alert.UID, err)
-		return "", fmt.Errorf("error updating alert: %v", err)
+		return AlertDeployment{}, fmt.Errorf("error updating alert: %v", err)
 	}
-	return uid, nil
+	return deployment, nil
 }
 
-func (d *Deployer) updateAlert(ctx context.Context, content string, createIfNotFound bool) (string, bool, error) {
+func (d *Deployer) updateAlert(ctx context.Context, content string, createIfNotFound bool) (AlertDeployment, bool, error) {
 	//  Return values:
-	// 1. UID of the alert
+	// 1. Deployment details of the alert
 	// 2. Whether the alert had to be (re-)created. If createIfNotFound is false, this will always be false.
 	// 3. Error if any
 
 	// Retrieve some alert information
 	alert, err := parseAlert(content)
 	if err != nil {
-		return "", false, err
+		return AlertDeployment{}, false, err
 	}
+	deployment := AlertDeployment{UID: alert.UID, Title: alert.Title}
 	d.groupsToUpdate[alert.RuleGroup] = true
 
 	// Prepare the request
 	path := fmt.Sprintf("api/v1/provisioning/alert-rules/%s", alert.UID)
 	res, err := d.client.PutRaw(ctx, path, []byte(content))
 	if err != nil {
-		return "", false, err
+		return AlertDeployment{}, false, err
 	}
 	defer res.Body.Close()
 
@@ -471,20 +465,20 @@ func (d *Deployer) updateAlert(ctx context.Context, content string, createIfNotF
 		// If an alert has been manually deleted in Grafana, and the deployer isn't aware of it, then next time it's modified
 		// it will try to update it. This will fail with a 404 error, so we need to create it instead
 		log.Printf("Alert %s not found for update, (re-)creating it instead", alert.UID)
-		uid, _, err := d.createAlert(ctx, content, false)
+		createdDeployment, _, err := d.createAlert(ctx, content, false)
 		if err != nil {
 			log.Printf("Can't create alert: %v", err)
-			return "", true, err
+			return AlertDeployment{}, true, err
 		}
-		return uid, true, nil
+		return createdDeployment, true, nil
 	} else if res.StatusCode != http.StatusOK {
 		log.Printf("Can't update alert. Status: %d", res.StatusCode)
-		return "", false, fmt.Errorf("error updating alert: returned status %s", res.Status)
+		return AlertDeployment{}, false, fmt.Errorf("error updating alert: returned status %s", res.Status)
 	}
 
 	log.Printf("Alert %s (%s) updated", alert.UID, alert.Title)
 
-	return alert.UID, false, nil
+	return deployment, false, nil
 }
 
 func (d *Deployer) updateAlertGroupInterval(ctx context.Context, folderUID string, group string, interval int64) error {

--- a/internal/deploy/deployer.go
+++ b/internal/deploy/deployer.go
@@ -50,6 +50,12 @@ type Deployer struct {
 	groupsToUpdate map[string]bool
 }
 
+// AlertDeployment identifies a deployed alert and its display title.
+type AlertDeployment struct {
+	UID   string `json:"uid"`
+	Title string `json:"title"`
+}
+
 func NewDeployer() *Deployer {
 	return &Deployer{
 		groupsToUpdate: map[string]bool{},
@@ -69,11 +75,11 @@ func (d *Deployer) IsFreshDeploy() bool {
 	return d.config.freshDeploy
 }
 
-func (d *Deployer) Deploy(ctx context.Context) ([]string, []string, []string, error) {
+func (d *Deployer) Deploy(ctx context.Context) ([]AlertDeployment, []AlertDeployment, []AlertDeployment, error) {
 	// Lists to store the alerts that were created, updated and deleted at any point during the deployment
-	alertsCreated := make([]string, len(d.config.alertsToAdd))
-	alertsUpdated := make([]string, len(d.config.alertsToUpdate))
-	alertsDeleted := make([]string, len(d.config.alertsToRemove))
+	alertsCreated := make([]AlertDeployment, 0, len(d.config.alertsToAdd))
+	alertsUpdated := make([]AlertDeployment, 0, len(d.config.alertsToUpdate))
+	alertsDeleted := make([]AlertDeployment, 0, len(d.config.alertsToRemove))
 
 	log.Printf("Preparing to deploy %d alerts, update %d alerts and delete %d alerts",
 		len(d.config.alertsToAdd), len(d.config.alertsToUpdate), len(d.config.alertsToRemove))
@@ -88,6 +94,7 @@ func (d *Deployer) Deploy(ctx context.Context) ([]string, []string, []string, er
 			err := fmt.Errorf("invalid alert filename: %s", alertFile)
 			return alertsCreated, alertsUpdated, alertsDeleted, err
 		}
+		alertTitle := d.getAlertTitle(ctx, alertUID)
 		uid, err := d.deleteAlert(ctx, alertUID)
 		if err != nil {
 			return alertsCreated, alertsUpdated, alertsDeleted, err
@@ -95,7 +102,7 @@ func (d *Deployer) Deploy(ctx context.Context) ([]string, []string, []string, er
 		// UID could be empty if the alert was not found
 		// In this case, we don't want to add it to the list of deleted alerts
 		if uid != "" {
-			alertsDeleted = append(alertsDeleted, uid)
+			alertsDeleted = append(alertsDeleted, AlertDeployment{UID: uid, Title: alertTitle})
 		}
 	}
 	// Process alert CREATIONS
@@ -105,16 +112,20 @@ func (d *Deployer) Deploy(ctx context.Context) ([]string, []string, []string, er
 			log.Printf("Can't read file %s: %v", alertFile, err)
 			return alertsCreated, alertsUpdated, alertsDeleted, err
 		}
+		alert, err := parseAlert(content)
+		if err != nil {
+			return alertsCreated, alertsUpdated, alertsDeleted, err
+		}
 		uid, updated, err := d.createAlert(ctx, content, true)
 		if err != nil {
 			return alertsCreated, alertsUpdated, alertsDeleted, err
 		}
 		if updated {
 			// If the alert was updated, we need to add it to the list of updated alerts
-			alertsUpdated = append(alertsUpdated, uid)
+			alertsUpdated = append(alertsUpdated, AlertDeployment{UID: uid, Title: alert.Title})
 		} else {
 			// If the alert was created, we need to add it to the list of created alerts
-			alertsCreated = append(alertsCreated, uid)
+			alertsCreated = append(alertsCreated, AlertDeployment{UID: uid, Title: alert.Title})
 		}
 	}
 	// Process alert UPDATES
@@ -122,6 +133,10 @@ func (d *Deployer) Deploy(ctx context.Context) ([]string, []string, []string, er
 		content, err := shared.ReadLocalFile(alertFile)
 		if err != nil {
 			log.Printf("Can't read file %s: %v", alertFile, err)
+			return alertsCreated, alertsUpdated, alertsDeleted, err
+		}
+		alert, err := parseAlert(content)
+		if err != nil {
 			return alertsCreated, alertsUpdated, alertsDeleted, err
 		}
 		uid, created, err := d.updateAlert(ctx, content, true)
@@ -133,10 +148,10 @@ func (d *Deployer) Deploy(ctx context.Context) ([]string, []string, []string, er
 		// So we take this into account for the reporting
 		if created {
 			// If the alert was created, we need to add it to the list of created alerts
-			alertsCreated = append(alertsCreated, uid)
+			alertsCreated = append(alertsCreated, AlertDeployment{UID: uid, Title: alert.Title})
 		} else {
 			// If the alert was updated, we need to add it to the list of updated alerts
-			alertsUpdated = append(alertsUpdated, uid)
+			alertsUpdated = append(alertsUpdated, AlertDeployment{UID: uid, Title: alert.Title})
 		}
 	}
 
@@ -152,10 +167,10 @@ func (d *Deployer) Deploy(ctx context.Context) ([]string, []string, []string, er
 	return alertsCreated, alertsUpdated, alertsDeleted, nil
 }
 
-func (d *Deployer) WriteOutput(alertsCreated []string, alertsUpdated []string, alertsDeleted []string) error {
-	alertsCreatedStr := strings.Join(alertsCreated, " ")
-	alertsUpdatedStr := strings.Join(alertsUpdated, " ")
-	alertsDeletedStr := strings.Join(alertsDeleted, " ")
+func (d *Deployer) WriteOutput(alertsCreated []AlertDeployment, alertsUpdated []AlertDeployment, alertsDeleted []AlertDeployment) error {
+	alertsCreatedStr := strings.Join(alertDeploymentUIDs(alertsCreated), " ")
+	alertsUpdatedStr := strings.Join(alertDeploymentUIDs(alertsUpdated), " ")
+	alertsDeletedStr := strings.Join(alertDeploymentUIDs(alertsDeleted), " ")
 
 	if err := shared.SetOutput("alerts_created", alertsCreatedStr); err != nil {
 		return err
@@ -166,7 +181,37 @@ func (d *Deployer) WriteOutput(alertsCreated []string, alertsUpdated []string, a
 	if err := shared.SetOutput("alerts_deleted", alertsDeletedStr); err != nil {
 		return err
 	}
+	if err := setAlertDeploymentOutput("alerts_created_details", alertsCreated); err != nil {
+		return err
+	}
+	if err := setAlertDeploymentOutput("alerts_updated_details", alertsUpdated); err != nil {
+		return err
+	}
+	if err := setAlertDeploymentOutput("alerts_deleted_details", alertsDeleted); err != nil {
+		return err
+	}
 	return nil
+}
+
+func alertDeploymentUIDs(alerts []AlertDeployment) []string {
+	uids := make([]string, 0, len(alerts))
+	for _, alert := range alerts {
+		if alert.UID != "" {
+			uids = append(uids, alert.UID)
+		}
+	}
+	return uids
+}
+
+func setAlertDeploymentOutput(name string, alerts []AlertDeployment) error {
+	if alerts == nil {
+		alerts = []AlertDeployment{}
+	}
+	details, err := json.Marshal(alerts)
+	if err != nil {
+		return fmt.Errorf("error encoding deployment details: %w", err)
+	}
+	return shared.SetOutput(name, string(details))
 }
 
 func (d *Deployer) LoadConfig(_ context.Context) error {
@@ -506,6 +551,15 @@ func (d *Deployer) deleteAlert(ctx context.Context, uid string) (string, error) 
 	log.Printf("Alert %s deleted", uid)
 
 	return uid, nil
+}
+
+func (d *Deployer) getAlertTitle(ctx context.Context, uid string) string {
+	alert, err := d.getAlert(ctx, uid)
+	if err != nil || strings.TrimSpace(alert.Title) == "" {
+		log.Printf("Can't retrieve title for alert %s. Using UID instead.", sanitizeForLog(uid))
+		return uid
+	}
+	return alert.Title
 }
 
 func (d *Deployer) checkAlertsMatch(a, b model.Alert) bool {

--- a/internal/deploy/deployer_test.go
+++ b/internal/deploy/deployer_test.go
@@ -181,16 +181,16 @@ func TestUpdateAlert(t *testing.T) {
 	}
 
 	// Update an alert
-	uid, created, err := d.updateAlert(ctx, `{"uid":"abcd123","title":"Test alert", "folderUID": "efgh456", "orgID": 23}`, true)
+	deployment, created, err := d.updateAlert(ctx, `{"uid":"abcd123","title":"Test alert", "folderUID": "efgh456", "orgID": 23}`, true)
 	assert.NoError(t, err)
 	assert.Equal(t, false, created)
-	assert.Equal(t, "abcd123", uid)
+	assert.Equal(t, AlertDeployment{UID: "abcd123", Title: "Test alert"}, deployment)
 
 	// Try to update an alert that doesn't exist. This should lead to a creation
-	uid, created, err = d.updateAlert(ctx, `{"uid":"xyz123","title":"Test alert", "folderUID": "efgh456", "orgID": 23}`, true)
+	deployment, created, err = d.updateAlert(ctx, `{"uid":"xyz123","title":"Test alert", "folderUID": "efgh456", "orgID": 23}`, true)
 	assert.NoError(t, err)
 	assert.Equal(t, true, created)
-	assert.Equal(t, "xyz123", uid)
+	assert.Equal(t, AlertDeployment{UID: "xyz123", Title: "Test alert"}, deployment)
 }
 
 func mockServerUpdate(t *testing.T, existingAlerts []string) *httptest.Server {
@@ -283,16 +283,16 @@ func TestCreateAlert(t *testing.T) {
 	}
 
 	// Create an alert
-	uid, updated, err := d.createAlert(ctx, `{"uid":"abcd123","title":"Test alert", "folderUID": "efgh456", "orgID": 23}`, true)
+	deployment, updated, err := d.createAlert(ctx, `{"uid":"abcd123","title":"Test alert", "folderUID": "efgh456", "orgID": 23}`, true)
 	assert.NoError(t, err)
 	assert.Equal(t, false, updated)
-	assert.Equal(t, "abcd123", uid)
+	assert.Equal(t, AlertDeployment{UID: "abcd123", Title: "Test alert"}, deployment)
 
 	// Try to create an alert that already exists. This should lead to an update
-	uid, updated, err = d.createAlert(ctx, `{"uid":"xyz123","title":"Test alert", "folderUID": "efgh456", "orgID": 23}`, true)
+	deployment, updated, err = d.createAlert(ctx, `{"uid":"xyz123","title":"Test alert", "folderUID": "efgh456", "orgID": 23}`, true)
 	assert.NoError(t, err)
 	assert.Equal(t, true, updated)
-	assert.Equal(t, "xyz123", uid)
+	assert.Equal(t, AlertDeployment{UID: "xyz123", Title: "Test alert"}, deployment)
 
 	// Simulate a conflict (same alert UID but different folder)
 	_, _, err = d.createAlert(ctx, `{"uid":"xyz123","title":"Test alert", "folderUID": "efgh789", "orgID": 23}`, true)

--- a/internal/deploy/deployment_output_test.go
+++ b/internal/deploy/deployment_output_test.go
@@ -1,0 +1,97 @@
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/sigma-rule-deployment/shared"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteOutputIncludesDeploymentDetails(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_OUTPUT", outputPath)
+
+	deployer := NewDeployer()
+	created := []AlertDeployment{
+		{UID: "uid-z", Title: "Zulu rule"},
+		{UID: "uid-a", Title: "Alpha rule"},
+	}
+	deleted := []AlertDeployment{{UID: "uid-d", Title: "Deleted rule"}}
+
+	err := deployer.WriteOutput(created, nil, deleted)
+	assert.NoError(t, err)
+
+	outputs := readActionOutputs(t, outputPath)
+	assert.Equal(t, "uid-z uid-a", outputs["alerts_created"])
+	assert.Equal(t, "", outputs["alerts_updated"])
+	assert.Equal(t, "uid-d", outputs["alerts_deleted"])
+
+	var createdDetails []AlertDeployment
+	err = json.Unmarshal([]byte(outputs["alerts_created_details"]), &createdDetails)
+	assert.NoError(t, err)
+	assert.Equal(t, created, createdDetails)
+	assert.Equal(t, "[]", outputs["alerts_updated_details"])
+
+	var deletedDetails []AlertDeployment
+	err = json.Unmarshal([]byte(outputs["alerts_deleted_details"]), &deletedDetails)
+	assert.NoError(t, err)
+	assert.Equal(t, deleted, deletedDetails)
+}
+
+func TestGetAlertTitle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		switch r.URL.Path {
+		case alertingAPIPrefix + "/known":
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"uid":"known","title":"Known rule"}`))
+			assert.NoError(t, err)
+		case alertingAPIPrefix + "/untitled":
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"uid":"untitled","title":"  "}`))
+			assert.NoError(t, err)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	deployer := Deployer{
+		client: shared.NewGrafanaClient(
+			server.URL+"/",
+			"my-test-token",
+			"sigma-rule-deployment/deployer",
+			defaultRequestTimeout,
+		),
+	}
+
+	assert.Equal(t, "Known rule", deployer.getAlertTitle(context.Background(), "known"))
+	assert.Equal(t, "missing", deployer.getAlertTitle(context.Background(), "missing"))
+	assert.Equal(t, "untitled", deployer.getAlertTitle(context.Background(), "untitled"))
+}
+
+func readActionOutputs(t *testing.T, outputPath string) map[string]string {
+	t.Helper()
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outputs := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(content)), "\n") {
+		name, value, found := strings.Cut(line, "=")
+		if found {
+			outputs[name] = value
+		}
+	}
+	return outputs
+}

--- a/scripts/comment-sigma-results/test/deploymentComment.test.js
+++ b/scripts/comment-sigma-results/test/deploymentComment.test.js
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  buildDeploymentComment,
+  normalizeDeploymentResults,
+  parseDeploymentResults,
+} = require('../../../actions/deploy/deployment-comment.cjs');
+
+test('normalizeDeploymentResults sorts titles alphabetically and falls back to UID', () => {
+  const results = normalizeDeploymentResults([
+    { uid: 'uid-z', title: 'Zulu rule' },
+    { uid: 'uid-b', title: 'beta rule' },
+    { uid: 'uid-a', title: 'Alpha rule' },
+    { uid: 'uid-fallback', title: '  ' },
+    { uid: '' },
+  ]);
+
+  assert.deepStrictEqual(results, [
+    { uid: 'uid-a', title: 'Alpha rule' },
+    { uid: 'uid-b', title: 'beta rule' },
+    { uid: 'uid-fallback', title: 'uid-fallback' },
+    { uid: 'uid-z', title: 'Zulu rule' },
+  ]);
+});
+
+test('parseDeploymentResults prefers JSON details and falls back to UID output', () => {
+  assert.deepStrictEqual(
+    parseDeploymentResults('[{"uid":"uid-b","title":"Beta"},{"uid":"uid-a","title":"Alpha"}]', 'ignored'),
+    [
+      { uid: 'uid-a', title: 'Alpha' },
+      { uid: 'uid-b', title: 'Beta' },
+    ]
+  );
+
+  assert.deepStrictEqual(parseDeploymentResults('invalid-json', 'uid-z uid-a'), [
+    { uid: 'uid-a', title: 'uid-a' },
+    { uid: 'uid-z', title: 'uid-z' },
+  ]);
+});
+
+test('buildDeploymentComment uses sorted rule titles while preserving UID links', () => {
+  const comment = buildDeploymentComment({
+    created: [
+      { uid: 'uid-z', title: 'Zulu rule' },
+      { uid: 'uid-a', title: 'Alpha rule' },
+    ],
+    updated: [{ uid: 'uid-u', title: 'Updated rule' }],
+    deleted: [
+      { uid: 'uid-d2', title: 'Gamma rule' },
+      { uid: 'uid-d1', title: 'Beta rule' },
+    ],
+    grafanaInstance: '"https://grafana.example/"',
+  });
+
+  assert(comment.includes('| 2 | 1 | 2 |'));
+  assert(comment.includes('- [Alpha rule](https://grafana.example/alerting/grafana/uid-a/view)'));
+  assert(comment.includes('- [Zulu rule](https://grafana.example/alerting/grafana/uid-z/view)'));
+  assert(comment.indexOf('Alpha rule') < comment.indexOf('Zulu rule'));
+  assert(comment.indexOf('Beta rule') < comment.indexOf('Gamma rule'));
+  assert(!comment.includes('[uid-a]'));
+  assert(!comment.includes('/uid-d1/view'));
+});
+
+test('buildDeploymentComment renders titles without links when the Grafana URL is absent', () => {
+  const comment = buildDeploymentComment({
+    created: [{ uid: 'uid-a', title: 'Alpha rule' }],
+  });
+
+  assert(comment.includes('- Alpha rule'));
+  assert(!comment.includes('alerting/grafana'));
+});


### PR DESCRIPTION
## Summary
- show Sigma rule titles instead of UIDs in deployment status comments
- sort created, updated, and deleted rule titles alphabetically
- preserve existing UID outputs and alert links, with UID fallbacks when titles are unavailable

## Testing
- `go test ./...` (Linux)
- `npm test` in `scripts/comment-sigma-results`
- `golangci-lint run --new-from-rev=origin/main --timeout=5m`

Closes #241