### PR TITLE
ci: gated fork PR image build + integration test

### DIFF
--- a/.github/scripts/create-integration-test-pr.sh
+++ b/.github/scripts/create-integration-test-pr.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Creates (or refreshes) the "integration-test-pr-<N>" branch and draft PR in
+# the integration-test repo from the Sigma Rule Deployment PR's fixtures.
+#
+# This orchestration was previously inlined in .github/workflows/build-docker.yml
+# It is extracted into a script so the trusted (same-repo) and gated fork
+# (workflow_run) paths run the *identical* logic. Helper scripts are resolved
+# relative to THIS file so they always come from the same (trusted) checkout as
+# this script, never from whatever fixtures the PR provides.
+#
+# Required environment variables:
+#   TEST_REPO         - owner/name of the integration-test repo
+#   TEST_REPO_DIR     - path to the checked-out integration-test repo
+#   FIXTURES_DIR      - path to the SRD checkout containing integration-test/*
+#   GITHUB_PR_NUMBER  - the originating SRD pull request number
+#   ACTION_SHA        - the SRD PR head SHA (pins actions + docker image tag)
+#   RUN_TOKEN         - unique token guaranteeing a diff on re-runs
+#   GH_TOKEN          - GitHub App token with access to the integration-test repo
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$TEST_REPO_DIR"
+git fetch
+
+EXPECTED_HEAD_OID=$("$SCRIPT_DIR/checkout-or-create-branch.sh" \
+  "$TEST_REPO" \
+  "integration-test-pr-${GITHUB_PR_NUMBER}" \
+  main)
+
+# remove old test files, if they exist
+rm -rf ./rules
+rm -rf ./pipelines
+rm test.yml
+rm config.yml
+
+cp -R "$FIXTURES_DIR/integration-test/"* ./
+sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/convert@.*/uses: grafana\/sigma-rule-deployment\/actions\/convert@$ACTION_SHA/g" ./.github/workflows/convert-integrate-test.yml
+sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/integrate@.*/uses: grafana\/sigma-rule-deployment\/actions\/integrate@$ACTION_SHA/g" ./.github/workflows/convert-integrate-test.yml
+
+# add the action sha so that the integration test can add the check to this PR
+echo "$ACTION_SHA" > action_sha.txt
+echo "$GITHUB_PR_NUMBER" > github_pr.txt
+# per-run token guarantees a change even when re-running on the PR
+echo "$RUN_TOKEN" > run_attempt.txt
+
+git add -A
+
+"$SCRIPT_DIR/create-verified-commit.sh" \
+  "$TEST_REPO" \
+  "integration-test-pr-${GITHUB_PR_NUMBER}" \
+  "$EXPECTED_HEAD_OID" \
+  "update integration test configuration"
+
+RESULT=$(gh pr list --json id,title -H "integration-test-pr-${GITHUB_PR_NUMBER}" | jq -r '. | length')
+
+if [ "$RESULT" -eq 0 ]; then
+  gh pr create \
+    --title "Integration Test PR ${GITHUB_PR_NUMBER}" \
+    --body "This PR to test Sigma Rule Deployment App from Sigma Rule Deployment Integration Test App for grafana/sigma-rule-deployment#${GITHUB_PR_NUMBER}" \
+    --head "integration-test-pr-${GITHUB_PR_NUMBER}" \
+    --base main \
+    --draft \
+    --label "automated"
+fi

--- a/.github/scripts/update-integration-main.sh
+++ b/.github/scripts/update-integration-main.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Refreshes the integration-test repo's main branch to the SRD PR head SHA (via
+# the "integration-test-main-update-<N>" PR), waits for its checks, merges it,
+# then comments "sigma convert all" on the integration test PR to kick off the
+# comment-triggered integration test.
+#
+# Extracted from .github/workflows/build-docker.yml so the trusted (same-repo)
+# and gated fork (workflow_run) paths run identical logic. Helper scripts are
+# resolved relative to THIS file so they always come from the same (trusted)
+# checkout as this script.
+#
+# Required environment variables:
+#   TEST_REPO         - owner/name of the integration-test repo
+#   TEST_REPO_DIR     - path to the checked-out integration-test repo
+#   GITHUB_PR_NUMBER  - the originating SRD pull request number
+#   ACTION_SHA        - the SRD PR head SHA (pins actions + docker image tag)
+#   RUN_TOKEN         - unique token guaranteeing a diff on re-runs
+#   GH_TOKEN          - GitHub App token with access to the integration-test repo
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$TEST_REPO_DIR"
+git fetch
+git checkout main
+git pull
+
+EXPECTED_HEAD_OID=$("$SCRIPT_DIR/checkout-or-create-branch.sh" \
+  "$TEST_REPO" \
+  "integration-test-main-update-${GITHUB_PR_NUMBER}" \
+  main)
+
+sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/convert@.*/uses: grafana\/sigma-rule-deployment\/actions\/convert@$ACTION_SHA/g" ./.github/workflows/convert-integrate-comment-test.yml
+sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/integrate@.*/uses: grafana\/sigma-rule-deployment\/actions\/integrate@$ACTION_SHA/g" ./.github/workflows/convert-integrate-comment-test.yml
+
+# add the action sha so that the integration test can add the check to this PR
+echo "$ACTION_SHA" > action_sha.txt
+echo "$GITHUB_PR_NUMBER" > github_pr.txt
+# per-run token guarantees a change even when re-running on the PR
+echo "$RUN_TOKEN" > run_attempt.txt
+
+# only commit the relevant changed files
+git add .github/workflows/convert-integrate-comment-test.yml action_sha.txt github_pr.txt run_attempt.txt
+
+"$SCRIPT_DIR/create-verified-commit.sh" \
+  "$TEST_REPO" \
+  "integration-test-main-update-${GITHUB_PR_NUMBER}" \
+  "$EXPECTED_HEAD_OID" \
+  "update main branch to relevant hash"
+
+RESULT=$(gh pr list --json id,title -H "integration-test-main-update-${GITHUB_PR_NUMBER}" | jq -r '. | length')
+
+if [ "$RESULT" -eq 0 ]; then
+  gh pr create \
+    --title "Integration Test Main Update ${GITHUB_PR_NUMBER}" \
+    --body "This PR updates the main branch to the relevant hash for grafana/sigma-rule-deployment#${GITHUB_PR_NUMBER}" \
+    --head "integration-test-main-update-${GITHUB_PR_NUMBER}" \
+    --base main \
+    --label "automated" \
+    --draft
+fi
+sleep 10 # wait for the PR checks to start...
+
+# wait for the required PR checks to complete
+if gh pr checks "integration-test-main-update-${GITHUB_PR_NUMBER}" --watch; then
+  gh pr ready "integration-test-main-update-${GITHUB_PR_NUMBER}"
+  gh pr merge "integration-test-main-update-${GITHUB_PR_NUMBER}" --auto --squash
+  sleep 5 # wait for the merge to complete
+  gh pr comment "integration-test-pr-${GITHUB_PR_NUMBER}" --body "sigma convert all"
+else
+  echo "Integration Test Main Update PR failed"
+  exit 1
+fi

--- a/.github/workflows/build-docker-fork-consume.yml
+++ b/.github/workflows/build-docker-fork-consume.yml
@@ -1,0 +1,199 @@
+name: "Fork PR Image Push & Integration Test"
+
+# Human-gated consumer for fork pull request builds.
+#
+# WHY THIS EXISTS
+# A pull_request from a fork gets a read-only GITHUB_TOKEN and NO repository
+# secrets, so it can neither push the image to GHCR nor mint the GitHub App
+# token used to drive the cross-repo integration test. The build-docker.yml
+# "build" job therefore only builds + exports the fork's image as an artifact.
+#
+# This workflow runs on completion of that build. Because workflow_run always
+# executes the definition from the default branch, the logic here is trusted
+# and cannot be altered by the fork. The privileged job is bound to the
+# `fork-integration-test` environment, which REQUIRES a maintainer approval
+# before it runs — that approval is the human gate on running external code
+# with our secrets.
+#
+# SECURITY NOTES
+#   * The untrusted fork build produces only an artifact (no secrets, read-only
+#     token). Nothing privileged happens until a human approves.
+#   * Orchestration scripts are taken from the default branch checkout, never
+#     from the PR head, so the App token is never exposed to fork-authored
+#     scripts. Only the integration-test *fixtures* (rules/pipelines/config)
+#     come from the PR head.
+#   * The image built from the fork's code IS ultimately run by the
+#     integration-test repo (which has Vault access). The maintainer approving
+#     the environment deployment MUST review the fork diff — including any
+#     changes under actions/ and the Dockerfile — before approving.
+
+# workflow_run is used deliberately here and is the whole point of this file:
+# the untrusted fork build produces only an artifact (no secrets), and every
+# privileged action below is gated behind the `fork-integration-test`
+# environment's required-reviewer approval. Orchestration scripts are taken from
+# the default branch, never the fork PR head.
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: ["Build & Integration Test Image"]
+    types:
+      - completed
+
+# Serialize fork integration tests: like build-docker.yml, this workflow commits
+# to the integration-test repo's main branch, so concurrent runs must not race.
+# cancel-in-progress is false so we never kill an integration test mid-flight.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  triage:
+    # Only consider successful fork pull_request builds. The presence of the
+    # `pr-metadata` artifact (uploaded only on the fork path) is the signal that
+    # this was a fork PR that needs the gated flow.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    name: "Triage fork build"
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      is_fork: ${{ steps.meta.outputs.is_fork }}
+      pr_number: ${{ steps.meta.outputs.pr_number }}
+      head_sha: ${{ steps.meta.outputs.head_sha }}
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+    steps:
+      - name: Check for fork metadata artifact
+        id: check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const found = artifacts.data.artifacts.some(a => a.name === 'pr-metadata');
+            core.setOutput('found', found ? 'true' : 'false');
+      - name: Download metadata
+        if: steps.check.outputs.found == 'true'
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: pr-metadata
+          path: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: Parse metadata
+        id: meta
+        if: steps.check.outputs.found == 'true'
+        run: |
+          META=pr-metadata/metadata.json
+          # pr_number and head_sha are validated to avoid injecting anything odd
+          # into later steps; head_sha must be a 40-char hex, pr_number an integer.
+          PR_NUMBER=$(jq -r '.pr_number' "$META")
+          HEAD_SHA=$(jq -r '.head_sha' "$META")
+          IMAGE_TAG=$(jq -r '.image_tag' "$META")
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid pr_number: $PR_NUMBER" >&2; exit 1
+          fi
+          if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid head_sha: $HEAD_SHA" >&2; exit 1
+          fi
+          EXPECTED_TAG="ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:sha-${HEAD_SHA}"
+          if [ "$IMAGE_TAG" != "$EXPECTED_TAG" ]; then
+            echo "Unexpected image_tag: $IMAGE_TAG (expected $EXPECTED_TAG)" >&2; exit 1
+          fi
+          {
+            echo "is_fork=true"
+            echo "pr_number=$PR_NUMBER"
+            echo "head_sha=$HEAD_SHA"
+            echo "image_tag=$EXPECTED_TAG"
+          } >> "$GITHUB_OUTPUT"
+
+  push-and-test:
+    # Skipped for same-repo PRs (handled inline in build-docker.yml). The
+    # `fork-integration-test` environment must be configured in repo settings
+    # with required reviewers + a `main`-only deployment branch policy; that
+    # approval is what gates running the fork's code with our secrets.
+    needs: triage
+    if: needs.triage.outputs.is_fork == 'true'
+    name: "Push image & run integration test"
+    runs-on: ubuntu-latest
+    environment: fork-integration-test
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      actions: read
+    env:
+      PR_NUMBER: ${{ needs.triage.outputs.pr_number }}
+      HEAD_SHA: ${{ needs.triage.outputs.head_sha }}
+      IMAGE_TAG: ${{ needs.triage.outputs.image_tag }}
+    steps:
+      - name: Get GitHub App Token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: sigma-rule-deployment-app
+      # Trusted orchestration scripts come from the default branch (this repo's
+      # HEAD as checked out by workflow_run), NEVER from the fork PR head.
+      - name: Checkout trusted scripts (default branch)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          path: ./srd-trusted
+      # The integration-test fixtures (rules/pipelines/config) come from the
+      # fork PR head via the base repo's pull ref. This is data consumed by the
+      # test, not code executed with the App token.
+      - name: Checkout fork PR fixtures
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
+          persist-credentials: false
+          path: ./sigma-rule-deployment-fixtures
+      - name: Checkout Integration Test
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.get-github-app-token.outputs.token }}
+          persist-credentials: true
+          repository: grafana/sigma-rule-deployment-integration-test
+          path: ./sigma-rule-deployment-integration-test
+      - name: Download fork image artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: pr-image
+          path: /tmp/pr-image
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - name: "Login to GitHub Container Registry"
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Load and push fork image
+        run: |
+          docker load --input /tmp/pr-image/pr-image.tar
+          docker image inspect "$IMAGE_TAG" >/dev/null
+          docker push "$IMAGE_TAG"
+      - name: Create integration test PR
+        env:
+          TEST_REPO: grafana/sigma-rule-deployment-integration-test
+          TEST_REPO_DIR: ${{ github.workspace }}/sigma-rule-deployment-integration-test
+          FIXTURES_DIR: ${{ github.workspace }}/sigma-rule-deployment-fixtures
+          GITHUB_PR_NUMBER: ${{ env.PR_NUMBER }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          ACTION_SHA: ${{ env.HEAD_SHA }}
+          RUN_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: ${{ github.workspace }}/srd-trusted/.github/scripts/create-integration-test-pr.sh
+      - name: Update integration main branch and send test comment
+        env:
+          TEST_REPO: grafana/sigma-rule-deployment-integration-test
+          TEST_REPO_DIR: ${{ github.workspace }}/sigma-rule-deployment-integration-test
+          GITHUB_PR_NUMBER: ${{ env.PR_NUMBER }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          ACTION_SHA: ${{ env.HEAD_SHA }}
+          RUN_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
+        run: ${{ github.workspace }}/srd-trusted/.github/scripts/update-integration-main.sh

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -31,21 +31,82 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      # For fork pull requests the job's GITHUB_TOKEN is read-only for org
+      # packages, so we cannot (and must not) log in and push. Instead we build
+      # the image, export it as an artifact, and let the gated
+      # build-docker-fork-consume.yml workflow push it after a human approval.
+      - name: "Determine PR origin"
+        id: origin
+        if: github.event_name == 'pull_request'
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: "Login to GitHub Container Registry"
+        # Skip for fork PRs: the token cannot write org packages and login is
+        # not needed to build + export a local image artifact.
+        if: github.event_name != 'pull_request' || steps.origin.outputs.is_fork == 'false'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Build and Push (PR)"
+      - name: "Build and Push (same-repo PR)"
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.origin.outputs.is_fork == 'false'
         with:
           context: .
           file: ./Dockerfile
           tags: |
             ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:sha-${{ github.event.pull_request.head.sha }}
           push: true
+      - name: "Build and Export (fork PR)"
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        if: github.event_name == 'pull_request' && steps.origin.outputs.is_fork == 'true'
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: |
+            ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:sha-${{ github.event.pull_request.head.sha }}
+          push: false
+          outputs: type=docker,dest=/tmp/pr-image.tar
+      - name: "Write fork PR metadata"
+        if: github.event_name == 'pull_request' && steps.origin.outputs.is_fork == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          IMAGE_TAG: ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:sha-${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p /tmp/pr-metadata
+          jq -n \
+            --arg pr_number "$PR_NUMBER" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg head_repo "$HEAD_REPO" \
+            --arg image_tag "$IMAGE_TAG" \
+            '{pr_number: $pr_number, head_sha: $head_sha, head_repo: $head_repo, image_tag: $image_tag}' \
+            > /tmp/pr-metadata/metadata.json
+      - name: "Upload fork PR image artifact"
+        if: github.event_name == 'pull_request' && steps.origin.outputs.is_fork == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr-image
+          path: /tmp/pr-image.tar
+          retention-days: 1
+          if-no-files-found: error
+      - name: "Upload fork PR metadata artifact"
+        if: github.event_name == 'pull_request' && steps.origin.outputs.is_fork == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr-metadata
+          path: /tmp/pr-metadata/metadata.json
+          retention-days: 1
+          if-no-files-found: error
       - name: "Build and Push (Push)"
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         if: github.event_name == 'push'
@@ -67,7 +128,10 @@ jobs:
           push: true
 
   test-pr:
-    if: github.event_name == 'pull_request'
+    # Only same-repo PRs run the integration test inline here: they have secrets
+    # and a package-write token. Fork PRs are handled by the human-gated
+    # build-docker-fork-consume.yml workflow (triggered on this run completing).
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     name: "Integration Testing"
     runs-on: ubuntu-latest
     needs:
@@ -95,111 +159,21 @@ jobs:
           repository: grafana/sigma-rule-deployment-integration-test
           path: ./sigma-rule-deployment-integration-test
       - name: Create new branch
-        id: integration-pr
-        working-directory: ./sigma-rule-deployment-integration-test
         env:
+          TEST_REPO: grafana/sigma-rule-deployment-integration-test
+          TEST_REPO_DIR: ${{ github.workspace }}/sigma-rule-deployment-integration-test
+          FIXTURES_DIR: ${{ github.workspace }}/sigma-rule-deployment
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           ACTION_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          git fetch
-
-          EXPECTED_HEAD_OID=$(../sigma-rule-deployment/.github/scripts/checkout-or-create-branch.sh \
-            grafana/sigma-rule-deployment-integration-test \
-            "integration-test-pr-${GITHUB_PR_NUMBER}" \
-            main)
-
-          # remove old test files, if they exist
-          rm -rf ./rules
-          rm -rf ./pipelines
-          rm test.yml
-          rm config.yml
-
-          cp -R ../sigma-rule-deployment/integration-test/* ./
-          sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/convert@.*/uses: grafana\/sigma-rule-deployment\/actions\/convert@$ACTION_SHA/g" ./.github/workflows/convert-integrate-test.yml
-          sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/integrate@.*/uses: grafana\/sigma-rule-deployment\/actions\/integrate@$ACTION_SHA/g" ./.github/workflows/convert-integrate-test.yml
-
-          # add the action sha so that the integration test can add the check to this PR
-          echo "$ACTION_SHA" > action_sha.txt
-          echo "$GITHUB_PR_NUMBER" > github_pr.txt
-          # per-run token guarantees a change even when re-running on the PR
-          echo "$RUN_TOKEN" > run_attempt.txt
-
-          git add -A
-
-          ../sigma-rule-deployment/.github/scripts/create-verified-commit.sh \
-            grafana/sigma-rule-deployment-integration-test \
-            "integration-test-pr-${GITHUB_PR_NUMBER}" \
-            "$EXPECTED_HEAD_OID" \
-            "update integration test configuration"
-
-          RESULT=$(gh pr list --json id,title -H "integration-test-pr-${GITHUB_PR_NUMBER}" | jq -r '. | length')
-
-          if [ "$RESULT" -eq 0 ]; then
-            gh pr create \
-              --title "Integration Test PR ${GITHUB_PR_NUMBER}" \
-              --body "This PR to test Sigma Rule Deployment App from Sigma Rule Deployment Integration Test App for grafana/sigma-rule-deployment#${GITHUB_PR_NUMBER}" \
-              --head "integration-test-pr-${GITHUB_PR_NUMBER}" \
-              --base main \
-              --draft \
-              --label "automated"
-          fi
+        run: ${{ github.workspace }}/sigma-rule-deployment/.github/scripts/create-integration-test-pr.sh
       - name: Update integration main branch to latest and send test comment
-        working-directory: ./sigma-rule-deployment-integration-test
         env:
+          TEST_REPO: grafana/sigma-rule-deployment-integration-test
+          TEST_REPO_DIR: ${{ github.workspace }}/sigma-rule-deployment-integration-test
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           ACTION_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_TOKEN: ${{ github.run_id }}-${{ github.run_attempt }}
-        run: |
-          git fetch
-          git checkout main
-          git pull
-
-          EXPECTED_HEAD_OID=$(../sigma-rule-deployment/.github/scripts/checkout-or-create-branch.sh \
-            grafana/sigma-rule-deployment-integration-test \
-            "integration-test-main-update-${GITHUB_PR_NUMBER}" \
-            main)
-
-          sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/convert@.*/uses: grafana\/sigma-rule-deployment\/actions\/convert@$ACTION_SHA/g" ./.github/workflows/convert-integrate-comment-test.yml
-          sed -i "s/uses: grafana\/sigma-rule-deployment\/actions\/integrate@.*/uses: grafana\/sigma-rule-deployment\/actions\/integrate@$ACTION_SHA/g" ./.github/workflows/convert-integrate-comment-test.yml
-
-          # add the action sha so that the integration test can add the check to this PR
-          echo "$ACTION_SHA" > action_sha.txt
-          echo "$GITHUB_PR_NUMBER" > github_pr.txt
-          # per-run token guarantees a change even when re-running on the PR
-          echo "$RUN_TOKEN" > run_attempt.txt
-
-          # only commit the relevant changed files
-          git add .github/workflows/convert-integrate-comment-test.yml action_sha.txt github_pr.txt run_attempt.txt
-
-          ../sigma-rule-deployment/.github/scripts/create-verified-commit.sh \
-            grafana/sigma-rule-deployment-integration-test \
-            "integration-test-main-update-${GITHUB_PR_NUMBER}" \
-            "$EXPECTED_HEAD_OID" \
-            "update main branch to relevant hash"
-
-          RESULT=$(gh pr list --json id,title -H "integration-test-main-update-${GITHUB_PR_NUMBER}" | jq -r '. | length')
-
-          if [ "$RESULT" -eq 0 ]; then
-            gh pr create \
-              --title "Integration Test Main Update ${GITHUB_PR_NUMBER}" \
-              --body "This PR updates the main branch to the relevant hash for grafana/sigma-rule-deployment#${GITHUB_PR_NUMBER}" \
-              --head "integration-test-main-update-${GITHUB_PR_NUMBER}" \
-              --base main \
-              --label "automated" \
-              --draft
-          fi
-          sleep 10 # wait for the PR checks to start...
-
-          # wait for the required PR checks to complete
-          if gh pr checks "integration-test-main-update-${GITHUB_PR_NUMBER}" --watch; then
-            gh pr ready "integration-test-main-update-${GITHUB_PR_NUMBER}"
-            gh pr merge "integration-test-main-update-${GITHUB_PR_NUMBER}" --auto --squash
-            sleep 5 # wait for the merge to complete
-            gh pr comment "integration-test-pr-${GITHUB_PR_NUMBER}" --body "sigma convert all"
-          else
-            echo "Integration Test Main Update PR failed"
-            exit 1
-          fi
+        run: ${{ github.workspace }}/sigma-rule-deployment/.github/scripts/update-integration-main.sh


### PR DESCRIPTION
## Problem

Pull requests from **forks** (external contributors) fail the build/integration
pipeline. A `pull_request` from a fork gets a **read-only `GITHUB_TOKEN`** and
**no repository secrets**, so the `build` job in `build-docker.yml`:

1. cannot `push` the image to the `grafana` org GHCR namespace, and
2. couldn't mint the GitHub App token that drives the cross-repo integration test.

The image is the real deliverable: the integration-test repo runs
`docker run ghcr.io/grafana/.../sigma-rule-deployer:sha-<head-sha>`, so we must
build the fork's code, make that image reachable, and run the privileged
orchestration — **without exposing secrets to untrusted code**.

## Approach (Proposal 1: untrusted build → artifact, human-gated consume)

Split the pipeline into an untrusted half and a human-gated privileged half.
No `pull_request_target`.

* **`build-docker.yml`**
  * **Same-repo PRs**: unchanged — build+push inline, run the integration test
    inline. Maintainers keep their fully-automatic flow, no approval clicks.
  * **Fork PRs**: build with `push: false`, export the image as a tarball
    **artifact**, and upload a small metadata artifact (PR number, head SHA,
    image tag). No login, no secrets, read-only token.
  * The inline `test-pr` job is now gated to same-repo PRs only.
* **`build-docker-fork-consume.yml`** (new)
  * Triggers on `workflow_run` completion, so it runs the **default-branch**
    definition (trusted, fork can't alter it).
  * `triage` job detects a fork build via the `pr-metadata` artifact and
    validates the values (numeric PR number, 40-hex head SHA, expected tag).
  * `push-and-test` job is bound to the **`fork-integration-test` environment**
    (required reviewers). GitHub pauses it until a maintainer approves — that
    approval is the human gate. It then pushes the image and runs the
    integration orchestration.
* **Extracted orchestration** into `create-integration-test-pr.sh` and
  `update-integration-main.sh` so both paths run identical logic. For forks
  these scripts come from the **default branch**, never the PR head, so the App
  token is never exposed to fork-authored scripts; only the integration-test
  **fixtures** (rules/pipelines/config) come from the PR head.

## Trust boundary

The gate is "PR head is from a fork" == "author has no write access", which
matches today's implicit trust model. Same-repo PRs are already trusted with
secrets today; nothing changes for maintainers. We only *add* a gated path for
the case that currently just fails.

## ⚠️ Required manual setup (repo admin)

This PR references an environment that must be created in **Settings →
Environments** before the fork path works:

1. Create environment **`fork-integration-test`**.
2. **Required reviewers**: add the maintainer team/users (they need write
   access). Enable **"Prevent self-review"**.
3. **Deployment branches**: restrict to **`main` only** (Selected branches).
   This stops anyone from using the environment from a branch carrying a
   modified consume workflow.
4. *(Recommended)* Move the sensitive credentials (GitHub App id/private key,
   any GHCR token) to **environment secrets** on this environment so they only
   exist for post-approval jobs. Audit other consumers first
   (e.g. `close-integration-test.yml`).
5. *(Optional)* Disable "Allow administrators to bypass configured protection
   rules" for this environment.

## Residual risks / reviewer responsibilities

* The image built from the fork's code **is** ultimately executed by the
  integration-test repo (which has Vault access). The maintainer approving the
  environment deployment **must review the fork diff** — especially changes
  under `actions/` and the `Dockerfile` — before approving.
* On new pushes to the fork PR, a fresh `workflow_run` is produced and requires
  a **new** environment approval (approval is bound to a specific run/SHA), so
  approval can't be reused for unreviewed code.

## Validation done

* `actionlint` — clean.
* `shellcheck` — clean.
* `zizmor` — clean; the `dangerous-triggers` finding on `workflow_run` is
  deliberately suppressed inline with justification (it's the crux of the
  design and mitigated by the environment gate + trusted-script checkout).

## To confirm on a live fork PR (can't be tested locally)

* Cross-repo `docker load`/push + `download-artifact` with `run-id`.
* That `uses: grafana/sigma-rule-deployment/actions/convert@<fork-head-sha>`
  resolves in the integration-test repo (fork commit is reachable via the base
  repo's pull ref — this is the same assumption the existing head-SHA pinning
  relies on).
* Concurrency: fork consumes serialize among themselves; cross-path
  serialization with same-repo runs on the integration-test `main` branch is
  left as-is — flag for team review if collisions are a concern.
