### PR TITLE
Enhance error reporting for Sigma rule conversions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,10 @@ Actions and helper scripts that wrap it.
 
 ## Prerequisites
 
-- **Go 1.25.4** or newer
+- **Go** (check `go.mod` for the required version)
 - **[uv](https://docs.astral.sh/uv/)** for the Python action. `uv` provisions its own
   interpreter, so you don't need a system Python matching `requires-python`.
-- **Node 25** for the two JS scripts.
+- **Node.js** for the two JS scripts. (check `package.json` for minimum version)
 - **Docker** — only needed if you want to build or run the image locally.
 - **`shellcheck`**, **`hadolint`**, **`actionlint`**, **`golangci-lint`** — optional, but each
   is enforced by a CI workflow, so having them locally saves round-trips.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing to Sigma Rule Deployment
+
+Thanks for contributing! This document covers local development on **this** repository —
+the Action suite itself. If you're looking to _use_ the Actions in your own rule repo,
+see [GettingStarted.md](GettingStarted.md) instead.
+
+## Repository layout
+
+This repo ships one Docker image containing two runtimes, plus a set of thin composite
+Actions and helper scripts that wrap it.
+
+| Path                                                          | What it is                                                               | Language  |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------ | --------- |
+| `cmd/sigma-deployer/`                                         | Entrypoint for the unified Go binary (`integrate`, `deploy` subcommands) | Go        |
+| `internal/integrate/`                                         | Converts conversion output into Grafana alert rule definitions           | Go        |
+| `internal/deploy/`                                            | Provisions alert rules to Grafana                                        | Go        |
+| `internal/querytest/`                                         | Query testing + "Link to Explore" generation                             | Go        |
+| `internal/model/`                                             | Shared config/alert types                                                | Go        |
+| `shared/`                                                     | Config loading, Grafana HTTP client, utilities                           | Go        |
+| `actions/convert/`                                            | Sigma → query conversion via sigma-cli                                   | Python    |
+| `actions/{convert,integrate,deploy,validate}/action.yml`      | Composite Actions                                                        | YAML      |
+| `actions/sigma-validation/`                                   | Documentation only — wraps the upstream SigmaHQ validator                | —         |
+| `scripts/comment-sigma-results/`, `scripts/identify-commits/` | PR comment handling and commit identification                            | Node      |
+| `scripts/determine-image-ref/`                                | Maps an action ref to a Docker image tag                                 | Bash      |
+| `.github/scripts/`                                            | Branch creation and verified-commit helpers used by workflows            | Bash      |
+| `config/`                                                     | Config JSON schema, example config, reusable workflow templates          | YAML/JSON |
+| `integration-test/`                                           | Fixtures copied into the integration test repo on every PR               | YAML/JSON |
+| `Dockerfile`, `entrypoint.sh`                                 | The published image and its subcommand dispatch                          | —         |
+
+## Prerequisites
+
+- **Go 1.25.4** or newer
+- **[uv](https://docs.astral.sh/uv/)** for the Python action. `uv` provisions its own
+  interpreter, so you don't need a system Python matching `requires-python`.
+- **Node 25** for the two JS scripts.
+- **Docker** — only needed if you want to build or run the image locally.
+- **`shellcheck`**, **`hadolint`**, **`actionlint`**, **`golangci-lint`** — optional, but each
+  is enforced by a CI workflow, so having them locally saves round-trips.
+
+## Running the tests
+
+CI ([`.github/workflows/unit-test.yml`](.github/workflows/unit-test.yml)) is the source of
+truth. To reproduce it locally:
+
+### Go
+
+```bash
+go get ./...
+go test ./internal/integrate/... ./internal/deploy/... ./internal/querytest/...
+golangci-lint run --timeout=5m
+```
+
+Lint config lives in [`.golangci.yml`](.golangci.yml). Note that it uses `default: none` with
+an explicit enable list, and enables `gofumpt` and `goimports` as formatters — run
+`golangci-lint fmt` (or `gofumpt -w .`) before pushing.
+
+Go tests use table-driven `testify` assertions with fixtures under
+`internal/*/testdata/`. When you add a fixture, prefer extending an existing `testdata`
+config over introducing a parallel one.
+
+### Python (`actions/convert`)
+
+```bash
+uv sync -q --directory actions/convert
+uv sync -q --directory actions/convert --group dev
+uv run --directory actions/convert ruff check .
+uv run --directory actions/convert mypy .
+uv run --directory actions/convert pytest -v .
+```
+
+There's also a `make test` shortcut, which wraps the `pytest` invocation above.
+
+### Node scripts
+
+```bash
+cd scripts/comment-sigma-results && npm ci && npm test
+cd scripts/identify-commits    && npm ci && npm test
+```
+
+## Running the conversion against real rules
+
+Unit tests cover conversion logic, but for anything touching sigma-cli behaviour, backend
+options, or pipeline resolution, it's worth converting real rules. The Python action resolves
+paths relative to `PATH_PREFIX` (defaulting to `GITHUB_WORKSPACE`, then `.`), so you can point
+it at a rule repository:
+
+```bash
+GITHUB_WORKSPACE=$(realpath integration-test) \
+  uv run --directory actions/convert main.py --config config.yml
+```
+
+## Testing changes to the Actions themselves
+
+Composite Action and workflow changes can't be validated by unit tests. Two mechanisms exist:
+
+1. **Automatic integration test.** Every PR triggers
+   [`build-docker.yml`](.github/workflows/build-docker.yml), which builds and pushes a
+   PR-tagged image to GHCR, then opens a PR against
+   `grafana/sigma-rule-deployment-integration-test` with the contents of
+   [`integration-test/`](integration-test/) and the action refs rewritten to your commit SHA.
+   Check that PR's workflow runs to see your change end to end. Merging or closing your PR
+   triggers [`close-integration-test.yml`](.github/workflows/close-integration-test.yml) to
+   clean up.
+2. **Manual pinning.** Point a scratch repo's workflow at
+   `grafana/sigma-rule-deployment/actions/convert@<your-sha>`.
+   [`scripts/determine-image-ref`](scripts/determine-image-ref/README.md) decides which image
+   tag that resolves to: a version tag → that tag, `latest` → `main`, and a raw SHA →
+   `sha-<sha>`.
+
+If your change alters behaviour the integration test should cover, add or update fixtures in
+[`integration-test/`](integration-test/) in the same PR — including
+`integration-test/manual-fixtures/` if you touch the manual-modification preservation logic.
+
+## Conventions
+
+**Pinned Action SHAs.** Every `uses:` in this repo pins a full commit SHA with the version in
+a trailing comment (`uses: actions/checkout@9c091bb... # v7.0.0`). Renovate maintains these;
+match the format exactly when adding a new one.
+
+**Least-privilege workflows.** Workflows declare `permissions: {}` at the top level and grant
+the minimum per job. Keep it that way.
+
+**Untrusted input.** Pass workflow inputs to `run:` steps via `env:` and reference them as
+`"${INPUTS_FOO}"` rather than interpolating `${{ }}` directly into shell — see
+[`actions/validate/action.yml`](actions/validate/action.yml) for the pattern.
+
+**Config schema.** User-facing config changes must update
+[`config/schema.json`](config/schema.json) and
+[`config/config-example.yml`](config/config-example.yml) together, since the
+[`validate`](actions/validate/README.md) action checks user configs against the schema.
+
+**Documentation.** Each Action's `README.md` is its reference documentation. If you change
+inputs, outputs, or behaviour, update that README in the same PR — and
+[GettingStarted.md](GettingStarted.md) too if the change affects setup.
+
+## Releasing
+
+See [Releasing](README.md#releasing) in the README. Note that releases are immutable, so the
+SBOM must be attached while the release is still a draft — the tag push automates this.

--- a/actions/convert/README.md
+++ b/actions/convert/README.md
@@ -27,7 +27,7 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:  # Allow manual triggering (optional)
+  workflow_dispatch: # Allow manual triggering (optional)
 
 jobs:
   convert:
@@ -45,6 +45,12 @@ jobs:
           pretty_print: "true"
           all_rules: "false"
 ```
+
+## Outputs
+
+| Name                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| `conversion_errors` | List of conversion errors encountered during the conversion process (JSON array of error objects) |
 
 ## How It Works
 

--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -32,6 +32,11 @@ inputs:
     required: false
     default: "false"
 
+outputs:
+  conversion_errors:
+    description: "List of conversion errors encountered during the conversion process."
+    value: ${{ steps.set-output.outputs.conversion_errors }}
+
 runs:
   using: "composite"
   steps:
@@ -121,6 +126,7 @@ runs:
             -v "$(pwd):/sigma-rules" \
             -w /sigma-rules \
             -e GITHUB_WORKSPACE=/sigma-rules \
+            -e GITHUB_OUTPUT=/sigma-rules/github-output \
             -e CONFIG_PATH="$CONFIG_PATH" \
             -e PLUGIN_PACKAGES="$PLUGIN_PACKAGES" \
             -e RENDER_TRACEBACK="$RENDER_TRACEBACK" \
@@ -131,6 +137,13 @@ runs:
             -e MANUAL_FILES="$MANUAL_FILES" \
             "ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:$IMAGE_REF" \
             convert
+
+    - name: Set output
+      id: set-output
+      shell: bash
+      run: |
+        mv github-output $GITHUB_OUTPUT
+
 
     - name: Comment Conversions
       id: comment-conversions
@@ -145,6 +158,7 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_ACTIONS: 'true'
         RULE_DIRECTORY_PATH: ${{ github.workspace }}
+        CONVERSION_ERRORS: ${{ steps.set-output.outputs.conversion_errors }}
       run: |
         # Generate comment data (git operations)
         git add "$CONVERSION_PATH"

--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -197,6 +197,7 @@ def convert_rules(
         print(f"Marking manually-modified conversion file as manual: {manual_file}")
 
     conversions_to_delete = []
+    conversion_errors = []
     # Convert Sigma rules to the target format per each conversion object in the config
     for conversion in config.get("conversions", []):
         # If the conversion name is not unique, we'll overwrite the output file,
@@ -394,6 +395,14 @@ def convert_rules(
                 # If an error occurred, print the output of the command. Sometimes the output
                 # doesn't contain anything.
                 print(f"Output:\n{result.output}".strip())
+                conversion_errors.append(
+                    {
+                        "conversion_name": name,
+                        "input_file": str(rel_input_path),
+                        "output": result.output.strip(),
+                    }
+                )
+
             else:
                 queries = [
                     line
@@ -438,6 +447,15 @@ def convert_rules(
                 print(f"Removing {deleted_file}")
                 os.remove(deleted_file)
 
+    # If there were any conversion errors, send them to $GITHUB_OUTPUT for the GitHub Actions workflow to pick up and display in the UI.
+    if conversion_errors:
+        github_output_path = os.getenv("GITHUB_OUTPUT")
+        if github_output_path:
+            with open(github_output_path, "a") as f:
+                f.write(f"conversion_errors={json.dumps(conversion_errors)}\n")
+        else:
+            print("GITHUB_OUTPUT environment variable not set, cannot write conversion errors to GitHub Actions output")
+            
 
 def is_safe_path(base_dir: str | Path, target_path: str | Path) -> bool:
     """

--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -451,11 +451,11 @@ def convert_rules(
     if conversion_errors:
         github_output_path = os.getenv("GITHUB_OUTPUT")
         if github_output_path:
-            with open(github_output_path, "a") as f:
-                f.write(f"conversion_errors={json.dumps(conversion_errors)}\n")
+            with open(github_output_path, "a", encoding="utf-8") as f:
+                f.write(f"conversion_errors={json.dumps(conversion_errors).decode('utf-8')}\n")
         else:
             print("GITHUB_OUTPUT environment variable not set, cannot write conversion errors to GitHub Actions output")
-            
+
 
 def is_safe_path(base_dir: str | Path, target_path: str | Path) -> bool:
     """

--- a/actions/convert/test_convert.py
+++ b/actions/convert/test_convert.py
@@ -371,6 +371,159 @@ def test_convert_rules_handles_empty_output_on_rule(temp_workspace, mock_config)
     assert not output_file.exists()
 
 
+@pytest.fixture
+def failing_convert():
+    """Patch the Sigma CLI to fail, as it does for an unconvertible rule.
+
+    The CLI exits non-zero, which CliRunner turns into a SystemExit on
+    result.exception, so the real error text is only in result.output.
+    """
+    mock_result = MagicMock()
+    mock_result.exception = SystemExit(1)
+    mock_result.exc_info = (SystemExit, SystemExit(1), None)
+    mock_result.exit_code = 1
+    mock_result.output = (
+        'Errors found in Sigma rules:\n* Unknown modifier "bogus" in rules/test.yml\n'
+    )
+    with patch("click.testing.CliRunner.invoke", return_value=mock_result):
+        yield mock_result
+
+
+def read_conversion_errors(github_output):
+    """Read the conversion_errors value written to a GITHUB_OUTPUT file."""
+    lines = github_output.read_text(encoding="utf-8").splitlines()
+    values = [line for line in lines if line.startswith("conversion_errors=")]
+    assert len(values) == 1, f"expected one conversion_errors line, got {lines}"
+    return json.loads(values[0].removeprefix("conversion_errors="))
+
+
+def test_conversion_errors_written_to_github_output(
+    failing_convert, temp_workspace, mock_config, monkeypatch, tmp_path
+):
+    """Test that a failed conversion is written to GITHUB_OUTPUT."""
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    convert_rules(config=mock_config, path_prefix=temp_workspace, all_rules=True)
+
+    errors = read_conversion_errors(github_output)
+    assert len(errors) == 1
+    assert errors[0]["conversion_name"] == "test_conversion"
+    # The input file must be relative to the workspace, so the Action can link to it
+    assert errors[0]["input_file"] == "rules/test.yml"
+    assert 'Unknown modifier "bogus"' in errors[0]["output"]
+
+
+def test_conversion_errors_written_as_a_single_line(
+    failing_convert, temp_workspace, mock_config, monkeypatch, tmp_path
+):
+    """Test that a multi-line error stays on one line, as GITHUB_OUTPUT requires."""
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    convert_rules(config=mock_config, path_prefix=temp_workspace, all_rules=True)
+
+    contents = github_output.read_text(encoding="utf-8")
+    assert len(contents.splitlines()) == 1
+    # JSON encoding must escape the newlines rather than emit them literally
+    assert "\\n" in contents
+
+
+def test_conversion_errors_written_as_decoded_json(
+    failing_convert, temp_workspace, mock_config, monkeypatch, tmp_path
+):
+    """Test that the value is JSON and not a stringified Python bytes object."""
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    convert_rules(config=mock_config, path_prefix=temp_workspace, all_rules=True)
+
+    contents = github_output.read_text(encoding="utf-8")
+    assert contents.startswith("conversion_errors=[")
+    assert "conversion_errors=b'" not in contents
+
+
+def test_no_conversion_errors_written_on_success(
+    temp_workspace, mock_config, monkeypatch, tmp_path
+):
+    """Test that nothing is written to GITHUB_OUTPUT when every rule converts."""
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    convert_rules(config=mock_config, path_prefix=temp_workspace, all_rules=True)
+
+    output_file = temp_workspace / "conversions" / "test_conversion_test.json"
+    assert output_file.exists(), "expected the conversion to succeed"
+    assert not github_output.exists()
+
+
+def test_conversion_errors_without_github_output(
+    failing_convert, temp_workspace, mock_config, monkeypatch, capsys
+):
+    """Test that a failed conversion outside Actions warns instead of raising."""
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    convert_rules(config=mock_config, path_prefix=temp_workspace, all_rules=True)
+
+    assert "GITHUB_OUTPUT environment variable not set" in capsys.readouterr().out
+
+
+def test_conversion_errors_one_entry_per_failed_rule(
+    failing_convert, temp_workspace, mock_config, monkeypatch, tmp_path
+):
+    """Test that each failed rule gets its own entry."""
+    second_rule = temp_workspace / "rules" / "test2.yml"
+    second_rule.write_text(
+        (temp_workspace / "rules" / "test.yml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    convert_rules(config=mock_config, path_prefix=temp_workspace, all_rules=True)
+
+    errors = read_conversion_errors(github_output)
+    assert sorted(error["input_file"] for error in errors) == [
+        "rules/test.yml",
+        "rules/test2.yml",
+    ]
+
+
+def test_conversion_error_does_not_stop_later_conversions(
+    temp_workspace, mock_config, monkeypatch, tmp_path
+):
+    """Test that a rule failing does not prevent the remaining rules converting."""
+    second_rule = temp_workspace / "rules" / "test2.yml"
+    second_rule.write_text(
+        (temp_workspace / "rules" / "test.yml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    github_output = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    failure = MagicMock()
+    failure.exception = SystemExit(1)
+    failure.exc_info = (SystemExit, SystemExit(1), None)
+    failure.exit_code = 1
+    failure.output = "Errors found in Sigma rules:\n* Unknown modifier\n"
+
+    success = MagicMock()
+    success.exception = None
+    success.exc_info = None
+    success.exit_code = 0
+    success.stdout = 'Parsing Sigma rules\n{job="test"}\n'
+
+    # Rules are converted in glob order, which is not guaranteed, so only assert
+    # on the counts rather than on which of the two rules failed
+    with patch("click.testing.CliRunner.invoke", side_effect=[failure, success]):
+        convert_rules(config=mock_config, path_prefix=temp_workspace, all_rules=True)
+
+    errors = read_conversion_errors(github_output)
+    assert len(errors) == 1
+    written = list((temp_workspace / "conversions").glob("*.json"))
+    assert len(written) == 1, "the rule that converted should still be written"
+
+
 def test_load_rule_valid_yaml():
     """Test loading a valid YAML rule file."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:

--- a/integration-test/config.yml
+++ b/integration-test/config.yml
@@ -8,6 +8,16 @@ conversion_defaults:
   file_pattern: "*.yml"
   data_source: grafanacloud-logs
 conversions:
+  - name: faulty
+    input:
+      - "rules/faulty.yml"
+    backend_options:
+      case_sensitive: true
+    pipelines:
+      - pipelines/datasources/test-1.yml
+      - pipelines/test-1.yml
+    rule_group: Every 1 Hour
+    time_window: 1h
   - name: github_audit
     input:
       - "rules/test*"

--- a/integration-test/rules/faulty.yml
+++ b/integration-test/rules/faulty.yml
@@ -1,0 +1,17 @@
+title: Faulty GitHub Test Rule
+id: 700f552f-0fa9-4bfe-bbaf-bbbde94c1c8c
+status: test
+description: Detects a repository being deleted.
+author: jamesc-grafana
+date: 2025-09-259
+logsource:
+  product: github
+  service: audit
+detection:
+  selection:
+    action:
+      - "repo.destroy"
+  condition: selection
+falsepositives:
+  - Validate the deletion activity is permitted. The "actor" field need to be validated.
+level: informational

--- a/integration-test/rules/faulty.yml
+++ b/integration-test/rules/faulty.yml
@@ -1,9 +1,9 @@
 title: Faulty GitHub Test Rule
 id: 700f552f-0fa9-4bfe-bbaf-bbbde94c1c8c
 status: test
-description: Detects a repository being deleted.
-author: jamesc-grafana
-date: 2025-09-259
+description: Should have a conversion fault
+author: flomon
+date: 2026-07-291
 logsource:
   product: github
   service: audit

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -117,11 +117,12 @@ function buildErrorsTableAndAnnotate(conversionErrors, repoUrl, headRef) {
 
   for (const error of conversionErrors) {
     const title = error.conversion_name;
-    const errorMessage = (error.output || 'Unknown error').replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');;
+    const errorMessage = error.output || 'Unknown error';
+    const errorCell = errorMessage.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
     const linkCell = error.input_file ? `[${path.basename(error.input_file)}](${repoUrl}/blob/${headRef}/${error.input_file})` : '-';
-    errorsTable += `| ${title} | ${linkCell} | ${errorMessage} |\n`;
+    errorsTable += `| ${title} | ${linkCell} | ${errorCell} |\n`;
 
-    // Set GitHub Actions warning annotation for the error
+    // Set GitHub Actions error annotation for the error.
     if (process.env.GITHUB_ACTIONS) {
       core.error(errorMessage, {
         title: `Conversion Error in ${title}`,
@@ -402,5 +403,5 @@ if (isMainModule) {
   main();
 }
 
-export { main, extractTitle, buildTestResultsTable };
+export { main, extractTitle, buildTestResultsTable, buildErrorsTableAndAnnotate };
 

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -108,6 +108,31 @@ function buildTestResultsTable(testResults) {
   return resultTable;
 }
 
+function buildErrorsTableAndAnnotate(conversionErrors, repoUrl, headRef) {
+  if (!conversionErrors || conversionErrors.length === 0) {
+    return '';
+  }
+
+  let errorsTable = `### Conversion Errors\n\n| File name | Link | Error message |\n| --- | --- | --- |\n`;
+
+  for (const error of conversionErrors) {
+    const title = error.conversion_name;
+    const errorMessage = (error.output || 'Unknown error').replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');;
+    const linkCell = error.input_file ? `[${path.basename(error.input_file)}](${repoUrl}/blob/${headRef}/${error.input_file})` : '-';
+    errorsTable += `| ${title} | ${linkCell} | ${errorMessage} |\n`;
+
+    // Set GitHub Actions warning annotation for the error
+    if (process.env.GITHUB_ACTIONS) {
+      core.error(errorMessage, {
+        title: `Conversion Error in ${title}`,
+        file: error.input_file || ''
+      })
+    }
+  }
+
+  return errorsTable;
+}
+
 /**
  * Get inputs from environment variables or CLI arguments
  */
@@ -127,6 +152,16 @@ function getInputs() {
       }
     }
 
+    let errorResults = null;
+    const errorResultsStr = core.getInput('conversion_errors') || process.env.CONVERSION_ERRORS;
+    if (errorResultsStr) {
+      try {
+        errorResults = JSON.parse(errorResultsStr);
+      } catch (e) {
+        console.log('Failed to parse CONVERSION_ERRORS JSON:', e.message);
+      }
+    }
+
     return {
       pullRequestNumber: core.getInput('pull_request_number') || process.env.PULL_REQUEST_NUMBER,
       changedFiles: core.getInput('changed_files') || process.env.CHANGED_FILES || '',
@@ -134,6 +169,7 @@ function getInputs() {
       commentTitle: core.getInput('comment_title') || process.env.COMMENT_TITLE,
       commentIdentifier: core.getInput('comment_identifier') || process.env.COMMENT_IDENTIFIER,
       testResults: testResults,
+      conversionErrors: errorResults,
       githubToken: core.getInput('github_token') || process.env.GITHUB_TOKEN,
     };
   } else {
@@ -158,7 +194,17 @@ function getInputs() {
         console.log('Failed to parse TEST_RESULTS JSON:', e.message);
       }
     }
-    
+
+    let errorResults = null;
+    const errorResultsStr = inputs.conversion_errors || process.env.CONVERSION_ERRORS;
+    if (errorResultsStr) {
+      try {
+        errorResults = JSON.parse(errorResultsStr);
+      } catch (e) {
+        console.log('Failed to parse CONVERSION_ERRORS JSON:', e.message);
+      }
+    }
+
     // Fallback to environment variables
     return {
       pullRequestNumber: inputs.pull_request_number || process.env.PULL_REQUEST_NUMBER,
@@ -167,6 +213,7 @@ function getInputs() {
       commentTitle: inputs.comment_title || process.env.COMMENT_TITLE,
       commentIdentifier: inputs.comment_identifier || process.env.COMMENT_IDENTIFIER,
       testResults: testResults,
+      conversionErrors: errorResults,
       githubToken: inputs.github_token || process.env.GITHUB_TOKEN,
     };
   }
@@ -246,6 +293,10 @@ async function main() {
 
     // Build test results table if TEST_RESULTS is provided
     const testResultsTable = inputs.testResults ? buildTestResultsTable(inputs.testResults) : '';
+
+    // Build errors table if CONVERSION_ERRORS is provided
+    const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+    const errorsTable = buildErrorsTableAndAnnotate(inputs.conversionErrors, repoUrl, prData.data.head.ref);
 
     const comment = `
 ### ${inputs.commentTitle}

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -314,6 +314,8 @@ ${changedFiles.length ? changedFilesList : "No files changed"}
 ${deletedFiles.length ? deletedFiles.map(file => `- ${file}`).join("\n") : "No files deleted"}
 
 ${testResultsTable ? '\n' + testResultsTable : ''}
+
+${errorsTable ? '\n' + errorsTable : ''}
 `;
 
     // GraphQL queries

--- a/scripts/comment-sigma-results/test/buildErrorsTableAndAnnotate.test.js
+++ b/scripts/comment-sigma-results/test/buildErrorsTableAndAnnotate.test.js
@@ -1,0 +1,126 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import * as commentModule from '../comment.js';
+
+// These tests run inside GitHub Actions, where GITHUB_ACTIONS is set. Unset it so
+// the annotations don't show up on the job running the tests.
+delete process.env.GITHUB_ACTIONS;
+
+const REPO_URL = 'https://github.com/grafana/sigma-internal';
+const HEAD_REF = 'my-branch';
+
+test('buildErrorsTableAndAnnotate - empty array returns empty string', () => {
+  const result = commentModule.buildErrorsTableAndAnnotate([], REPO_URL, HEAD_REF);
+  assert.strictEqual(result, '');
+});
+
+test('buildErrorsTableAndAnnotate - null returns empty string', () => {
+  const result = commentModule.buildErrorsTableAndAnnotate(null, REPO_URL, HEAD_REF);
+  assert.strictEqual(result, '');
+});
+
+test('buildErrorsTableAndAnnotate - undefined returns empty string', () => {
+  const result = commentModule.buildErrorsTableAndAnnotate(undefined, REPO_URL, HEAD_REF);
+  assert.strictEqual(result, '');
+});
+
+test('buildErrorsTableAndAnnotate - single error renders header and row', () => {
+  const conversionErrors = [
+    {
+      conversion_name: 'github_audit',
+      input_file: 'rules/okta_user_created.yml',
+      output: 'Unknown modifier "bogus"',
+    }
+  ];
+
+  const result = commentModule.buildErrorsTableAndAnnotate(conversionErrors, REPO_URL, HEAD_REF);
+
+  assert(result.includes('### Conversion Errors'));
+  assert(result.includes('| File name | Link | Error message |'));
+  assert(result.includes('github_audit'));
+  assert(result.includes('Unknown modifier "bogus"'));
+});
+
+test('buildErrorsTableAndAnnotate - links to the rule file at the head ref', () => {
+  const conversionErrors = [
+    {
+      conversion_name: 'github_audit',
+      input_file: 'rules/cloud/okta_user_created.yml',
+      output: 'boom',
+    }
+  ];
+
+  const result = commentModule.buildErrorsTableAndAnnotate(conversionErrors, REPO_URL, HEAD_REF);
+
+  // Link text is the basename, the href is the full path relative to the repo root
+  assert(result.includes(
+    '[okta_user_created.yml](https://github.com/grafana/sigma-internal/blob/my-branch/rules/cloud/okta_user_created.yml)'
+  ));
+});
+
+test('buildErrorsTableAndAnnotate - renders dash when input_file is missing', () => {
+  const conversionErrors = [
+    { conversion_name: 'github_audit', output: 'boom' }
+  ];
+
+  const result = commentModule.buildErrorsTableAndAnnotate(conversionErrors, REPO_URL, HEAD_REF);
+
+  assert(!result.includes(']('), 'should not render an empty markdown link');
+  const dataLine = result.split('\n').find(line => line.includes('github_audit'));
+  assert(dataLine.includes('| - |'), 'should render dash in link cell');
+});
+
+test('buildErrorsTableAndAnnotate - replaces newlines so the row stays on one line', () => {
+  const conversionErrors = [
+    {
+      conversion_name: 'github_audit',
+      input_file: 'rules/test.yml',
+      output: 'Errors found in Sigma rules:\n* Unknown modifier "bogus"',
+    }
+  ];
+
+  const result = commentModule.buildErrorsTableAndAnnotate(conversionErrors, REPO_URL, HEAD_REF);
+
+  assert(result.includes('Errors found in Sigma rules:<br>* Unknown modifier "bogus"'));
+  const dataLines = result.split('\n').filter(line => line.includes('github_audit'));
+  assert.strictEqual(dataLines.length, 1, 'a raw newline would split this into two rows');
+});
+
+test('buildErrorsTableAndAnnotate - escapes pipes in the error message', () => {
+  const conversionErrors = [
+    {
+      conversion_name: 'github_audit',
+      input_file: 'rules/test.yml',
+      // Loki queries are full of pipes, so this is the common case
+      output: '{job="x"} | json | line_format broke',
+    }
+  ];
+
+  const result = commentModule.buildErrorsTableAndAnnotate(conversionErrors, REPO_URL, HEAD_REF);
+
+  assert(result.includes('\\| json \\| line_format broke'));
+});
+
+test('buildErrorsTableAndAnnotate - falls back to Unknown error when output is empty', () => {
+  const conversionErrors = [
+    { conversion_name: 'github_audit', input_file: 'rules/test.yml', output: '' }
+  ];
+
+  const result = commentModule.buildErrorsTableAndAnnotate(conversionErrors, REPO_URL, HEAD_REF);
+
+  assert(result.includes('Unknown error'));
+});
+
+test('buildErrorsTableAndAnnotate - renders one row per error', () => {
+  const conversionErrors = [
+    { conversion_name: 'conversion_a', input_file: 'rules/a.yml', output: 'boom a' },
+    { conversion_name: 'conversion_b', input_file: 'rules/b.yml', output: 'boom b' },
+  ];
+
+  const result = commentModule.buildErrorsTableAndAnnotate(conversionErrors, REPO_URL, HEAD_REF);
+
+  assert(result.includes('conversion_a'));
+  assert(result.includes('boom a'));
+  assert(result.includes('conversion_b'));
+  assert(result.includes('boom b'));
+});


### PR DESCRIPTION
Collects all conversion errors during in convert.py during conversion step and stores error outputs in github-output so it can be picked up by comment.js. This then renders a table with file links in the comment if there were errors. Also an annotation is added to the action (and file) when errors are encountered. Action does not fail though (to not break current behavior).

Also an example of a faulty rule is added to `integration-test`.

closes #311 