### PR TITLE
Handle large comments

### DIFF
--- a/scripts/comment-sigma-results/README.md
+++ b/scripts/comment-sigma-results/README.md
@@ -46,7 +46,7 @@ node comment.js
 | `CHANGED_FILES` | Space-separated list of changed file paths | Yes |
 | `DELETED_FILES` | Space-separated list of deleted file paths | Yes |
 | `COMMENT_TITLE` | Title for the comment section | Yes |
-| `COMMENT_IDENTIFIER` | String to identify old comments for cleanup | Yes |
+| `COMMENT_IDENTIFIER` | String to identify old comments for cleanup (will be hidden in comment) | Yes |
 | `TEST_RESULTS` | JSON string of test results (object mapping file paths to arrays of QueryTestResult) | No |
 | `GITHUB_TOKEN` | GitHub token for API access | Yes |
 | `GITHUB_REPOSITORY` | Repository in format `owner/repo` | Yes (for local) |

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -91,14 +91,14 @@ async function main() {
     });
 
     for (const comment of comments?.repository?.pullRequest?.comments?.nodes ?? []) {
-      if (!comment.isMinimized && comment.bodyText.startsWith(inputs.commentIdentifier)) {
+      if (!comment.isMinimized && comment.body.startsWith(`<!-- ${inputs.commentIdentifier} -->`)) {
         await octokit.graphql(minimizeCommentMutation, {
           subjectId: comment.id
         });
       }
     }
 
-    const commentChunks = splitCommentIntoChunks(comment);
+    const commentChunks = splitCommentIntoChunks(comment, inputs.commentIdentifier);
     // Post new comment(s)
     for (const chunk of commentChunks) {
       await octokit.graphql(addCommentMutation, {

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -2,17 +2,17 @@
 
 /**
  * Comment Sigma Results Script
- * 
+ *
  * Posts a comment to a PR with Sigma rule conversion/integration results.
  * Can be run standalone or as part of a GitHub Action.
- * 
+ *
  * Usage:
  *   node comment.js [options]
- * 
+ *
  * Environment variables (for GitHub Actions):
  *   PULL_REQUEST_NUMBER, CHANGED_FILES, DELETED_FILES, COMMENT_TITLE,
  *   COMMENT_IDENTIFIER, TEST_RESULTS, GITHUB_TOKEN
- * 
+ *
  * CLI arguments (for local testing):
  *   --pr-number, --changed-files, --deleted-files, --title, --identifier,
  *   --test-results, --token
@@ -20,225 +20,12 @@
 
 import * as core from '@actions/core';
 import * as github from '@actions/github';
-import fs from 'fs';
-import path from 'path';
 
-// Get the root of the repository - this is used to resolve the absolute path to the file when the scripts runs from a different repo
-const repoRoot = process.env.RULE_DIRECTORY_PATH || process.cwd();
-
-/**
- * Extract title from JSON file
- */
-
-
-function extractTitle(filePath) {
-  try {
-    const absolutePath = path.isAbsolute(filePath)
-      ? filePath
-      : path.join(repoRoot, filePath);
-
-    if (!fs.existsSync(absolutePath)) {
-      console.log(`File does not exist: ${absolutePath}`);
-      return path.basename(filePath);
-    }
-
-    const content = fs.readFileSync(absolutePath, 'utf8');
-    
-    // Try JSON parsing first
-    try {
-      const jsonData = JSON.parse(content);
-      
-      // Check for title at top level (for alert rule files)
-      if (jsonData.title && typeof jsonData.title === 'string') {
-        return jsonData.title.trim();
-      }
-      
-      // Check for title in rules array (for conversion output files)
-      if (jsonData.rules && Array.isArray(jsonData.rules) && jsonData.rules.length > 0) {
-        const firstRule = jsonData.rules[0];
-        if (firstRule && firstRule.title && typeof firstRule.title === 'string') {
-          return firstRule.title.trim();
-        }
-      }
-    } catch (jsonError) {
-      // JSON parsing failed, will try regex fallback
-      console.log(`JSON parsing failed for ${filePath}: ${jsonError.message}, trying regex fallback`);
-    }
-
-    // Fallback to regex if JSON parsing didn't find title
-    const titleMatch = content.match(/"title":\s*"([^"]+)"/);
-    if (titleMatch && titleMatch[1]) {
-      return titleMatch[1].trim();
-    }
-
-    // Final fallback to filename if no title found
-    console.log(`No title found in ${filePath} using JSON or regex`);
-    return path.basename(filePath);
-  } catch (error) {
-    console.log(`Error reading file ${filePath}: ${error.message}`);
-    // Fallback to filename if file can't be read
-    return path.basename(filePath);
-  }
-}
-
-/**
- * Build test results table from TEST_RESULTS JSON
- */
-function buildTestResultsTable(testResults) {
-  if (!testResults || Object.keys(testResults).length === 0) {
-    return '';
-  }
-
-  let resultTable = `### Test Results\n\n| File name | Link | Result count | Execution time | Bytes processed | Errors |\n| --- | --- | --- | --- | --- | --- |\n`;
-
-  for (const [filePath, results] of Object.entries(testResults)) {
-    const title = extractTitle(filePath);
-    for (const result of results) {
-      const executionTime = result.stats.executionTime?.unit
-        ? `${result.stats.executionTime.value} ${result.stats.executionTime.unit}`.trim()
-        : '-';
-      const bytesProcessed = result.stats.bytesProcessed?.unit
-        ? `${result.stats.bytesProcessed.value.toLocaleString()} ${result.stats.bytesProcessed.unit}`.trim()
-        : '-';
-      const linkCell = result.link ? `[See in Explore](${result.link})` : '-';
-      resultTable += `| ${title} | ${linkCell} | ${result.stats.count} | ${executionTime} | ${bytesProcessed} | ${result.stats.errors.length} |\n`;
-    }
-  }
-
-  return resultTable;
-}
-
-function buildErrorsTableAndAnnotate(conversionErrors, repoUrl, headRef) {
-  if (!conversionErrors || conversionErrors.length === 0) {
-    return '';
-  }
-
-  let errorsTable = `### Conversion Errors\n\n| File name | Link | Error message |\n| --- | --- | --- |\n`;
-
-  for (const error of conversionErrors) {
-    const title = error.conversion_name;
-    const errorMessage = error.output || 'Unknown error';
-    const errorCell = errorMessage.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
-    const linkCell = error.input_file ? `[${path.basename(error.input_file)}](${repoUrl}/blob/${headRef}/${error.input_file})` : '-';
-    errorsTable += `| ${title} | ${linkCell} | ${errorCell} |\n`;
-
-    // Set GitHub Actions error annotation for the error.
-    if (process.env.GITHUB_ACTIONS) {
-      core.error(errorMessage, {
-        title: `Conversion Error in ${title}`,
-        file: error.input_file || ''
-      })
-    }
-  }
-
-  return errorsTable;
-}
-
-/**
- * Get inputs from environment variables or CLI arguments
- */
-function getInputs() {
-  // Check if running in GitHub Actions
-  const isGitHubActions = !!process.env.GITHUB_ACTIONS;
-  
-  if (isGitHubActions) {
-    // Use @actions/core for GitHub Actions
-    let testResults = null;
-    const testResultsStr = core.getInput('test_results') || process.env.TEST_RESULTS;
-    if (testResultsStr) {
-      try {
-        testResults = JSON.parse(testResultsStr);
-      } catch (e) {
-        console.log('Failed to parse TEST_RESULTS JSON:', e.message);
-      }
-    }
-
-    let errorResults = null;
-    const errorResultsStr = core.getInput('conversion_errors') || process.env.CONVERSION_ERRORS;
-    if (errorResultsStr) {
-      try {
-        errorResults = JSON.parse(errorResultsStr);
-      } catch (e) {
-        console.log('Failed to parse CONVERSION_ERRORS JSON:', e.message);
-      }
-    }
-
-    return {
-      pullRequestNumber: core.getInput('pull_request_number') || process.env.PULL_REQUEST_NUMBER,
-      changedFiles: core.getInput('changed_files') || process.env.CHANGED_FILES || '',
-      deletedFiles: core.getInput('deleted_files') || process.env.DELETED_FILES || '',
-      commentTitle: core.getInput('comment_title') || process.env.COMMENT_TITLE,
-      commentIdentifier: core.getInput('comment_identifier') || process.env.COMMENT_IDENTIFIER,
-      testResults: testResults,
-      conversionErrors: errorResults,
-      githubToken: core.getInput('github_token') || process.env.GITHUB_TOKEN,
-    };
-  } else {
-    // Parse CLI arguments for local testing
-    const args = process.argv.slice(2);
-    const inputs = {};
-    
-    for (let i = 0; i < args.length; i += 2) {
-      const key = args[i]?.replace(/^--/, '');
-      const value = args[i + 1];
-      if (key && value) {
-        inputs[key.replace(/-/g, '_')] = value;
-      }
-    }
-    
-    let testResults = null;
-    const testResultsStr = inputs.test_results || process.env.TEST_RESULTS;
-    if (testResultsStr) {
-      try {
-        testResults = JSON.parse(testResultsStr);
-      } catch (e) {
-        console.log('Failed to parse TEST_RESULTS JSON:', e.message);
-      }
-    }
-
-    let errorResults = null;
-    const errorResultsStr = inputs.conversion_errors || process.env.CONVERSION_ERRORS;
-    if (errorResultsStr) {
-      try {
-        errorResults = JSON.parse(errorResultsStr);
-      } catch (e) {
-        console.log('Failed to parse CONVERSION_ERRORS JSON:', e.message);
-      }
-    }
-
-    // Fallback to environment variables
-    return {
-      pullRequestNumber: inputs.pull_request_number || process.env.PULL_REQUEST_NUMBER,
-      changedFiles: inputs.changed_files || process.env.CHANGED_FILES || '',
-      deletedFiles: inputs.deleted_files || process.env.DELETED_FILES || '',
-      commentTitle: inputs.comment_title || process.env.COMMENT_TITLE,
-      commentIdentifier: inputs.comment_identifier || process.env.COMMENT_IDENTIFIER,
-      testResults: testResults,
-      conversionErrors: errorResults,
-      githubToken: inputs.github_token || process.env.GITHUB_TOKEN,
-    };
-  }
-}
-
-/**
- * Get GitHub context (repo owner/name)
- */
-function getContext() {
-  if (process.env.GITHUB_ACTIONS) {
-    // Use GitHub Actions context
-    return github.context;
-  } else {
-    // Parse from GITHUB_REPOSITORY env var or CLI args
-    const repo = process.env.GITHUB_REPOSITORY || '';
-    const [owner, repoName] = repo.split('/');
-    return {
-      repo: {
-        owner: owner || process.env.GITHUB_REPO_OWNER || '',
-        repo: repoName || process.env.GITHUB_REPO_NAME || '',
-      }
-    };
-  }
-}
+import { buildChangedFilesList, buildCommentBody } from './lib/comment-body.js';
+import { extractTitle } from './lib/extract-title.js';
+import { getContext, getInputs } from './lib/inputs.js';
+import { addCommentMutation, minimizeCommentMutation, oldCommentQuery } from './lib/queries.js';
+import { buildErrorsTableAndAnnotate, buildTestResultsTable } from './lib/tables.js';
 
 /**
  * Main function
@@ -246,7 +33,7 @@ function getContext() {
 async function main() {
   try {
     const inputs = getInputs();
-    
+
     // Validate required inputs
     if (!inputs.pullRequestNumber) {
       throw new Error('pull_request_number is required');
@@ -263,104 +50,47 @@ async function main() {
 
     const changedFiles = inputs.changedFiles.split(' ').filter(file => file.trim() !== '');
     const deletedFiles = inputs.deletedFiles.split(' ').filter(file => file.trim() !== '');
-    
+
     // Initialize GitHub client
     const octokit = github.getOctokit(inputs.githubToken);
     const context = getContext();
-    
+
     if (!context.repo.owner || !context.repo.repo) {
       throw new Error('Repository owner and name must be provided via GITHUB_REPOSITORY or GITHUB_REPO_OWNER/GITHUB_REPO_NAME');
     }
-    
+
     // Get PR data
     const prData = await octokit.rest.pulls.get({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: parseInt(inputs.pullRequestNumber, 10),
     });
-    
+
     if (!prData.data) {
       console.log(`No pull request found for ${context.repo.owner}/${context.repo.repo}#${inputs.pullRequestNumber}`);
       return;
     }
 
     const nodeId = prData.data.node_id;
+    const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
 
     // Build file list with titles
-    const changedFilesList = changedFiles.map(file => {
-      const title = extractTitle(file);
-      return `- [${title}](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${prData.data.head.ref}/${file})`;
-    }).join("\n");
+    const changedFilesList = buildChangedFilesList(changedFiles, repoUrl, prData.data.head.ref);
 
     // Build test results table if TEST_RESULTS is provided
     const testResultsTable = inputs.testResults ? buildTestResultsTable(inputs.testResults) : '';
 
     // Build errors table if CONVERSION_ERRORS is provided
-    const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
     const errorsTable = buildErrorsTableAndAnnotate(inputs.conversionErrors, repoUrl, prData.data.head.ref);
 
-    const comment = `
-### ${inputs.commentTitle}
-
-| Changed | Deleted |
-| --- | --- |
-| ${changedFiles.length} | ${deletedFiles.length} |
-
-### Changed Files
-
-${changedFiles.length ? changedFilesList : "No files changed"}
-
-### Deleted Files
-
-${deletedFiles.length ? deletedFiles.map(file => `- ${file}`).join("\n") : "No files deleted"}
-
-${testResultsTable ? '\n' + testResultsTable : ''}
-
-${errorsTable ? '\n' + errorsTable : ''}
-`;
-
-    // GraphQL queries
-    const oldCommentQuery = `query GetPRComments($owner: String!, $name: String!, $number: Int!) {
-        repository(owner: $owner, name: $name) {
-          id
-          pullRequest(number: $number) {
-            title
-            comments(last: 100) {
-              nodes {
-                id
-                bodyText
-                isMinimized
-                author {
-                  login
-                }
-              }
-            }
-          }
-        }
-    }`;
-
-    const minimizeCommentMutation = `mutation MinimizeComment($subjectId: ID!) {
-      minimizeComment(input: {
-        subjectId: $subjectId,
-        classifier: OUTDATED
-      }) {
-        clientMutationId
-      }
-    }`;
-
-    const addCommentMutation = `mutation AddComment($body: String!, $subjectId: ID!) {
-      addComment(input: {
-        body: $body,
-        subjectId: $subjectId,
-      }) {
-        subject {
-          id
-          ... on PullRequest {
-            number
-          }
-        }
-      }
-    }`;
+    const comment = buildCommentBody({
+      commentTitle: inputs.commentTitle,
+      changedFiles,
+      deletedFiles,
+      changedFilesList,
+      testResultsTable,
+      errorsTable,
+    });
 
     // Find and minimize old comments
     const comments = await octokit.graphql(oldCommentQuery, {
@@ -404,4 +134,3 @@ if (isMainModule) {
 }
 
 export { main, extractTitle, buildTestResultsTable, buildErrorsTableAndAnnotate };
-

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -21,7 +21,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { buildChangedFilesList, buildCommentBody } from './lib/comment-body.js';
+import { buildCommentBody } from './lib/comment-body.js';
 import { extractTitle } from './lib/extract-title.js';
 import { getContext, getInputs } from './lib/inputs.js';
 import { addCommentMutation, minimizeCommentMutation, oldCommentQuery } from './lib/queries.js';
@@ -72,24 +72,15 @@ async function main() {
     }
 
     const nodeId = prData.data.node_id;
-    const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
-
-    // Build file list with titles
-    const changedFilesList = buildChangedFilesList(changedFiles, repoUrl, prData.data.head.ref);
-
-    // Build test results table if TEST_RESULTS is provided
-    const testResultsTable = inputs.testResults ? buildTestResultsTable(inputs.testResults) : '';
-
-    // Build errors table if CONVERSION_ERRORS is provided
-    const errorsTable = buildErrorsTableAndAnnotate(inputs.conversionErrors, repoUrl, prData.data.head.ref);
 
     const comment = buildCommentBody({
       commentTitle: inputs.commentTitle,
       changedFiles,
       deletedFiles,
-      changedFilesList,
-      testResultsTable,
-      errorsTable,
+      testResults: inputs.testResults,
+      conversionErrors: inputs.conversionErrors,
+      repoUrl: `https://github.com/${context.repo.owner}/${context.repo.repo}`,
+      headRef: prData.data.head.ref,
     });
 
     // Find and minimize old comments

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -98,11 +98,14 @@ async function main() {
       }
     }
 
-    // Post new comment
-    await octokit.graphql(addCommentMutation, {
-      body: comment,
-      subjectId: nodeId
-    });
+    const commentChunks = splitCommentIntoChunks(comment);
+    // Post new comment(s)
+    for (const chunk of commentChunks) {
+      await octokit.graphql(addCommentMutation, {
+        body: chunk,
+        subjectId: nodeId
+      });
+    }
 
     console.log('Comment posted successfully');
   } catch (error) {

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -21,7 +21,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 
-import { buildCommentBody } from './lib/comment-body.js';
+import { buildCommentBody, splitCommentIntoChunks } from './lib/comment-body.js';
 import { extractTitle } from './lib/extract-title.js';
 import { getContext, getInputs } from './lib/inputs.js';
 import { addCommentMutation, minimizeCommentMutation, oldCommentQuery } from './lib/queries.js';

--- a/scripts/comment-sigma-results/lib/comment-body.js
+++ b/scripts/comment-sigma-results/lib/comment-body.js
@@ -1,4 +1,5 @@
 import { extractTitle } from './extract-title.js';
+import { buildErrorsTableAndAnnotate, buildTestResultsTable } from './tables.js';
 
 /**
  * Build the markdown bullet list of changed files, linking each one to its
@@ -12,16 +13,28 @@ export function buildChangedFilesList(changedFiles, repoUrl, headRef) {
 }
 
 /**
- * Assemble the full comment body from its pre-rendered sections.
+ * Render the full comment body: the changed/deleted file lists, the test
+ * results table (when TEST_RESULTS was provided) and the conversion errors
+ * table (when CONVERSION_ERRORS was provided).
  */
 export function buildCommentBody({
   commentTitle,
   changedFiles,
   deletedFiles,
-  changedFilesList,
-  testResultsTable,
-  errorsTable,
+  testResults,
+  conversionErrors,
+  repoUrl,
+  headRef,
 }) {
+  // Build file list with titles
+  const changedFilesList = buildChangedFilesList(changedFiles, repoUrl, headRef);
+
+  // Build test results table if TEST_RESULTS is provided
+  const testResultsTable = testResults ? buildTestResultsTable(testResults) : '';
+
+  // Build errors table if CONVERSION_ERRORS is provided
+  const errorsTable = buildErrorsTableAndAnnotate(conversionErrors, repoUrl, headRef);
+
   return `
 ### ${commentTitle}
 

--- a/scripts/comment-sigma-results/lib/comment-body.js
+++ b/scripts/comment-sigma-results/lib/comment-body.js
@@ -19,8 +19,11 @@ export function commentByteSize(text) {
   return Buffer.byteLength(text, 'utf8');
 }
 
-export function splitCommentIntoChunks(comment, maxCommentSize = MAX_COMMENT_SIZE) {
-  const safetyMargin = commentByteSize(":open_book: Part 100 of 100\n\n")
+export function splitCommentIntoChunks(comment, commentIdentifier, maxCommentSize = MAX_COMMENT_SIZE) {
+
+  const commentIdentifierLine = `<!-- ${commentIdentifier} -->\n`;
+
+  const safetyMargin = commentByteSize(":open_book: Part 100 of 100\n\n" + commentIdentifierLine);
 
   const chunks = [];
   let currentChunk = '';
@@ -87,6 +90,13 @@ export function splitCommentIntoChunks(comment, maxCommentSize = MAX_COMMENT_SIZ
       chunks[i] = `:open_book: Part ${i + 1} of ${chunks.length}\n\n` + chunks[i];
     }
   }
+
+  // Add comment identifier line to every chunk so that the minimize filter can match them all
+  for (let i = 0; i < chunks.length; i++) {
+    // Drop the chunk's leading newlines so the identifier line sits flush above the content
+    chunks[i] = commentIdentifierLine + chunks[i].replace(/^\n+/, '');
+  }
+
   return chunks;
 }
 

--- a/scripts/comment-sigma-results/lib/comment-body.js
+++ b/scripts/comment-sigma-results/lib/comment-body.js
@@ -82,7 +82,7 @@ export function splitCommentIntoChunks(comment, maxCommentSize = MAX_COMMENT_SIZ
   }
 
   if(chunks.length > 1) {
-    chunks[0] += `:open_book: Part 1 of ${chunks.length}`;
+    chunks[0] += `\n\n:open_book: Part 1 of ${chunks.length}`;
     for(let i = 1; i < chunks.length; i++) {
       chunks[i] = `:open_book: Part ${i + 1} of ${chunks.length}\n\n` + chunks[i];
     }

--- a/scripts/comment-sigma-results/lib/comment-body.js
+++ b/scripts/comment-sigma-results/lib/comment-body.js
@@ -1,6 +1,8 @@
 import { extractTitle } from './extract-title.js';
 import { buildErrorsTableAndAnnotate, buildTestResultsTable } from './tables.js';
 
+export const MAX_COMMENT_SIZE = 262144; // GitHub's maximum comment size in bytes according to https://github.com/dead-claudia/github-limits#issue-comments
+
 /**
  * Build the markdown bullet list of changed files, linking each one to its
  * blob on the PR's head ref.
@@ -10,6 +12,82 @@ export function buildChangedFilesList(changedFiles, repoUrl, headRef) {
     const title = extractTitle(file);
     return `- [${title}](${repoUrl}/blob/${headRef}/${file})`;
   }).join("\n");
+}
+
+export function commentByteSize(text) {
+  // Calculate the byte size of the comment text in UTF-8 encoding
+  return Buffer.byteLength(text, 'utf8');
+}
+
+export function splitCommentIntoChunks(comment, maxCommentSize = MAX_COMMENT_SIZE) {
+  const safetyMargin = commentByteSize(":open_book: Part 100 of 100\n\n")
+
+  const chunks = [];
+  let currentChunk = '';
+  let lastTableHeader = ''; // Keep track of the last table header to avoid splitting in the middle of a table
+
+  for (const line of comment.split('\n')) {
+    const lineWithNewline = line + '\n';
+
+    // If the line is a table header, store it
+    if (line.startsWith('|') && line.includes('---')) {
+      lastTableHeader = currentChunk.split('\n').slice(0,-1).pop() + '\n' + lineWithNewline;
+    } else if (!line.startsWith('|') && lastTableHeader) {
+      lastTableHeader = ''; // Reset if we are no longer in a table
+    }
+
+    if (commentByteSize(currentChunk + lineWithNewline) > maxCommentSize - safetyMargin) {
+
+      let preparedNewChunk = '';
+
+      // If the current chunk ends with a headline (e.g. ### Test Results) (and a table header), move it to the next chunk
+      const chunkLines = currentChunk.split('\n');
+      if (chunkLines.at(-1) === '') {
+        chunkLines.pop(); // currentChunk always ends in a newline, drop the empty trailing entry
+      }
+      for (let i = chunkLines.length - 1; i >= 0; i--) {
+        const line = chunkLines[i];
+
+        if(line.trim() === '') {
+          preparedNewChunk = line + '\n' + preparedNewChunk;
+          chunkLines.splice(i, 1);
+        } else if (line.startsWith('### ')) {
+          preparedNewChunk = line + '\n' + preparedNewChunk;
+          chunkLines.splice(i, 1);
+        } else if( line.startsWith('|') && line.includes('---')) {
+          preparedNewChunk = chunkLines.splice(i-1, 2).join('\n') + '\n' + preparedNewChunk;
+          i--; // Skip the next line since we already spliced it
+        }
+        else {
+          break;
+        }
+
+      }
+
+      // If preparedNewChunk is still empty and we are in the middle of a table, copy the last table header to the next chunk
+      if (preparedNewChunk === '' && lastTableHeader) {
+        preparedNewChunk = lastTableHeader;
+      }
+      
+      currentChunk = chunkLines.join('\n') + '\n';
+
+      chunks.push(currentChunk);
+      currentChunk = preparedNewChunk;
+    }
+    currentChunk += lineWithNewline;
+  }
+
+  if (currentChunk) {
+    chunks.push(currentChunk);
+  }
+
+  if(chunks.length > 1) {
+    chunks[0] += `:open_book: Part 1 of ${chunks.length}`;
+    for(let i = 1; i < chunks.length; i++) {
+      chunks[i] = `:open_book: Part ${i + 1} of ${chunks.length}\n\n` + chunks[i];
+    }
+  }
+  return chunks;
 }
 
 /**
@@ -35,7 +113,7 @@ export function buildCommentBody({
   // Build errors table if CONVERSION_ERRORS is provided
   const errorsTable = buildErrorsTableAndAnnotate(conversionErrors, repoUrl, headRef);
 
-  return `
+  const comment = `
 ### ${commentTitle}
 
 | Changed | Deleted |
@@ -54,4 +132,6 @@ ${testResultsTable ? '\n' + testResultsTable : ''}
 
 ${errorsTable ? '\n' + errorsTable : ''}
 `;
+
+  return comment;
 }

--- a/scripts/comment-sigma-results/lib/comment-body.js
+++ b/scripts/comment-sigma-results/lib/comment-body.js
@@ -1,0 +1,44 @@
+import { extractTitle } from './extract-title.js';
+
+/**
+ * Build the markdown bullet list of changed files, linking each one to its
+ * blob on the PR's head ref.
+ */
+export function buildChangedFilesList(changedFiles, repoUrl, headRef) {
+  return changedFiles.map(file => {
+    const title = extractTitle(file);
+    return `- [${title}](${repoUrl}/blob/${headRef}/${file})`;
+  }).join("\n");
+}
+
+/**
+ * Assemble the full comment body from its pre-rendered sections.
+ */
+export function buildCommentBody({
+  commentTitle,
+  changedFiles,
+  deletedFiles,
+  changedFilesList,
+  testResultsTable,
+  errorsTable,
+}) {
+  return `
+### ${commentTitle}
+
+| Changed | Deleted |
+| --- | --- |
+| ${changedFiles.length} | ${deletedFiles.length} |
+
+### Changed Files
+
+${changedFiles.length ? changedFilesList : "No files changed"}
+
+### Deleted Files
+
+${deletedFiles.length ? deletedFiles.map(file => `- ${file}`).join("\n") : "No files deleted"}
+
+${testResultsTable ? '\n' + testResultsTable : ''}
+
+${errorsTable ? '\n' + errorsTable : ''}
+`;
+}

--- a/scripts/comment-sigma-results/lib/extract-title.js
+++ b/scripts/comment-sigma-results/lib/extract-title.js
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Extract title from JSON file
+ */
+export function extractTitle(filePath) {
+  try {
+    // Get the root of the repository - this is used to resolve the absolute path to the file when the scripts runs from a different repo
+    const repoRoot = process.env.RULE_DIRECTORY_PATH || process.cwd();
+
+    const absolutePath = path.isAbsolute(filePath)
+      ? filePath
+      : path.join(repoRoot, filePath);
+
+    if (!fs.existsSync(absolutePath)) {
+      console.log(`File does not exist: ${absolutePath}`);
+      return path.basename(filePath);
+    }
+
+    const content = fs.readFileSync(absolutePath, 'utf8');
+
+    // Try JSON parsing first
+    try {
+      const jsonData = JSON.parse(content);
+
+      // Check for title at top level (for alert rule files)
+      if (jsonData.title && typeof jsonData.title === 'string') {
+        return jsonData.title.trim();
+      }
+
+      // Check for title in rules array (for conversion output files)
+      if (jsonData.rules && Array.isArray(jsonData.rules) && jsonData.rules.length > 0) {
+        const firstRule = jsonData.rules[0];
+        if (firstRule && firstRule.title && typeof firstRule.title === 'string') {
+          return firstRule.title.trim();
+        }
+      }
+    } catch (jsonError) {
+      // JSON parsing failed, will try regex fallback
+      console.log(`JSON parsing failed for ${filePath}: ${jsonError.message}, trying regex fallback`);
+    }
+
+    // Fallback to regex if JSON parsing didn't find title
+    const titleMatch = content.match(/"title":\s*"([^"]+)"/);
+    if (titleMatch && titleMatch[1]) {
+      return titleMatch[1].trim();
+    }
+
+    // Final fallback to filename if no title found
+    console.log(`No title found in ${filePath} using JSON or regex`);
+    return path.basename(filePath);
+  } catch (error) {
+    console.log(`Error reading file ${filePath}: ${error.message}`);
+    // Fallback to filename if file can't be read
+    return path.basename(filePath);
+  }
+}

--- a/scripts/comment-sigma-results/lib/inputs.js
+++ b/scripts/comment-sigma-results/lib/inputs.js
@@ -1,0 +1,108 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+/**
+ * Get inputs from environment variables or CLI arguments
+ */
+export function getInputs() {
+  // Check if running in GitHub Actions
+  const isGitHubActions = !!process.env.GITHUB_ACTIONS;
+
+  if (isGitHubActions) {
+    // Use @actions/core for GitHub Actions
+    let testResults = null;
+    const testResultsStr = core.getInput('test_results') || process.env.TEST_RESULTS;
+    if (testResultsStr) {
+      try {
+        testResults = JSON.parse(testResultsStr);
+      } catch (e) {
+        console.log('Failed to parse TEST_RESULTS JSON:', e.message);
+      }
+    }
+
+    let errorResults = null;
+    const errorResultsStr = core.getInput('conversion_errors') || process.env.CONVERSION_ERRORS;
+    if (errorResultsStr) {
+      try {
+        errorResults = JSON.parse(errorResultsStr);
+      } catch (e) {
+        console.log('Failed to parse CONVERSION_ERRORS JSON:', e.message);
+      }
+    }
+
+    return {
+      pullRequestNumber: core.getInput('pull_request_number') || process.env.PULL_REQUEST_NUMBER,
+      changedFiles: core.getInput('changed_files') || process.env.CHANGED_FILES || '',
+      deletedFiles: core.getInput('deleted_files') || process.env.DELETED_FILES || '',
+      commentTitle: core.getInput('comment_title') || process.env.COMMENT_TITLE,
+      commentIdentifier: core.getInput('comment_identifier') || process.env.COMMENT_IDENTIFIER,
+      testResults: testResults,
+      conversionErrors: errorResults,
+      githubToken: core.getInput('github_token') || process.env.GITHUB_TOKEN,
+    };
+  } else {
+    // Parse CLI arguments for local testing
+    const args = process.argv.slice(2);
+    const inputs = {};
+
+    for (let i = 0; i < args.length; i += 2) {
+      const key = args[i]?.replace(/^--/, '');
+      const value = args[i + 1];
+      if (key && value) {
+        inputs[key.replace(/-/g, '_')] = value;
+      }
+    }
+
+    let testResults = null;
+    const testResultsStr = inputs.test_results || process.env.TEST_RESULTS;
+    if (testResultsStr) {
+      try {
+        testResults = JSON.parse(testResultsStr);
+      } catch (e) {
+        console.log('Failed to parse TEST_RESULTS JSON:', e.message);
+      }
+    }
+
+    let errorResults = null;
+    const errorResultsStr = inputs.conversion_errors || process.env.CONVERSION_ERRORS;
+    if (errorResultsStr) {
+      try {
+        errorResults = JSON.parse(errorResultsStr);
+      } catch (e) {
+        console.log('Failed to parse CONVERSION_ERRORS JSON:', e.message);
+      }
+    }
+
+    // Fallback to environment variables
+    return {
+      pullRequestNumber: inputs.pull_request_number || process.env.PULL_REQUEST_NUMBER,
+      changedFiles: inputs.changed_files || process.env.CHANGED_FILES || '',
+      deletedFiles: inputs.deleted_files || process.env.DELETED_FILES || '',
+      commentTitle: inputs.comment_title || process.env.COMMENT_TITLE,
+      commentIdentifier: inputs.comment_identifier || process.env.COMMENT_IDENTIFIER,
+      testResults: testResults,
+      conversionErrors: errorResults,
+      githubToken: inputs.github_token || process.env.GITHUB_TOKEN,
+    };
+  }
+}
+
+/**
+ * Get GitHub context (repo owner/name)
+ */
+export function getContext() {
+  if (process.env.GITHUB_ACTIONS) {
+    // Use GitHub Actions context
+    return github.context;
+  } else {
+    // Parse from GITHUB_REPOSITORY env var or CLI args
+    const repo = process.env.GITHUB_REPOSITORY || '';
+    const [owner, repoName] = repo.split('/');
+    return {
+      repo: {
+        owner: owner || process.env.GITHUB_REPO_OWNER || '',
+        repo: repoName || process.env.GITHUB_REPO_NAME || '',
+      }
+    };
+  }
+}

--- a/scripts/comment-sigma-results/lib/queries.js
+++ b/scripts/comment-sigma-results/lib/queries.js
@@ -1,0 +1,45 @@
+/**
+ * GraphQL queries and mutations used to manage PR comments.
+ */
+
+export const oldCommentQuery = `query GetPRComments($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          id
+          pullRequest(number: $number) {
+            title
+            comments(last: 100) {
+              nodes {
+                id
+                bodyText
+                isMinimized
+                author {
+                  login
+                }
+              }
+            }
+          }
+        }
+    }`;
+
+export const minimizeCommentMutation = `mutation MinimizeComment($subjectId: ID!) {
+      minimizeComment(input: {
+        subjectId: $subjectId,
+        classifier: OUTDATED
+      }) {
+        clientMutationId
+      }
+    }`;
+
+export const addCommentMutation = `mutation AddComment($body: String!, $subjectId: ID!) {
+      addComment(input: {
+        body: $body,
+        subjectId: $subjectId,
+      }) {
+        subject {
+          id
+          ... on PullRequest {
+            number
+          }
+        }
+      }
+    }`;

--- a/scripts/comment-sigma-results/lib/queries.js
+++ b/scripts/comment-sigma-results/lib/queries.js
@@ -10,6 +10,7 @@ export const oldCommentQuery = `query GetPRComments($owner: String!, $name: Stri
             comments(last: 100) {
               nodes {
                 id
+                body
                 bodyText
                 isMinimized
                 author {

--- a/scripts/comment-sigma-results/lib/tables.js
+++ b/scripts/comment-sigma-results/lib/tables.js
@@ -1,0 +1,57 @@
+import * as core from '@actions/core';
+import path from 'path';
+
+import { extractTitle } from './extract-title.js';
+
+/**
+ * Build test results table from TEST_RESULTS JSON
+ */
+export function buildTestResultsTable(testResults) {
+  if (!testResults || Object.keys(testResults).length === 0) {
+    return '';
+  }
+
+  let resultTable = `### Test Results\n\n| File name | Link | Result count | Execution time | Bytes processed | Errors |\n| --- | --- | --- | --- | --- | --- |\n`;
+
+  for (const [filePath, results] of Object.entries(testResults)) {
+    const title = extractTitle(filePath);
+    for (const result of results) {
+      const executionTime = result.stats.executionTime?.unit
+        ? `${result.stats.executionTime.value} ${result.stats.executionTime.unit}`.trim()
+        : '-';
+      const bytesProcessed = result.stats.bytesProcessed?.unit
+        ? `${result.stats.bytesProcessed.value.toLocaleString()} ${result.stats.bytesProcessed.unit}`.trim()
+        : '-';
+      const linkCell = result.link ? `[See in Explore](${result.link})` : '-';
+      resultTable += `| ${title} | ${linkCell} | ${result.stats.count} | ${executionTime} | ${bytesProcessed} | ${result.stats.errors.length} |\n`;
+    }
+  }
+
+  return resultTable;
+}
+
+export function buildErrorsTableAndAnnotate(conversionErrors, repoUrl, headRef) {
+  if (!conversionErrors || conversionErrors.length === 0) {
+    return '';
+  }
+
+  let errorsTable = `### Conversion Errors\n\n| File name | Link | Error message |\n| --- | --- | --- |\n`;
+
+  for (const error of conversionErrors) {
+    const title = error.conversion_name;
+    const errorMessage = error.output || 'Unknown error';
+    const errorCell = errorMessage.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
+    const linkCell = error.input_file ? `[${path.basename(error.input_file)}](${repoUrl}/blob/${headRef}/${error.input_file})` : '-';
+    errorsTable += `| ${title} | ${linkCell} | ${errorCell} |\n`;
+
+    // Set GitHub Actions error annotation for the error.
+    if (process.env.GITHUB_ACTIONS) {
+      core.error(errorMessage, {
+        title: `Conversion Error in ${title}`,
+        file: error.input_file || ''
+      })
+    }
+  }
+
+  return errorsTable;
+}

--- a/scripts/comment-sigma-results/test/minimizesCorrectly.test.js
+++ b/scripts/comment-sigma-results/test/minimizesCorrectly.test.js
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import {
+  buildCommentBody,
+  splitCommentIntoChunks,
+} from "../lib/comment-body.js";
+
+/** The value actions/convert/action.yml passes as COMMENT_IDENTIFIER (and COMMENT_TITLE). */
+const COMMENT_IDENTIFIER = "Sigma Rule Conversions";
+
+function buildComment() {
+  return buildCommentBody({
+    commentTitle: COMMENT_IDENTIFIER,
+    changedFiles: Array.from({ length: 8 }, (_, i) => `rules/rule_${i}.json`),
+    deletedFiles: ["rules/old_rule.json"],
+    testResults: null,
+    conversionErrors: null,
+    repoUrl: "https://github.com/grafana/sigma-internal",
+    headRef: "my-branch",
+  });
+}
+
+test("a comment posted in one part is matched by the minimize filter", () => {
+  const comment = buildComment();
+
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER);
+
+  assert.strictEqual(chunks.length, 1);
+  assert(chunks[0].startsWith(`<!-- ${COMMENT_IDENTIFIER} -->`));
+});
+
+test("every part of a split comment is matched by the minimize filter", () => {
+  const comment = buildComment();
+
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 300);
+
+  assert(chunks.length > 1, "expected the comment to split into several parts");
+  // comment.js only minimizes old comments whose bodyText starts with the
+  // identifier, so a part it cannot match is left expanded on every re-run.
+  chunks.forEach((chunk, i) => {
+    assert(
+      chunk.startsWith(`<!-- ${COMMENT_IDENTIFIER} -->`),
+      `part ${i + 1} of ${chunks.length} would not be minimized, it starts with: ${JSON.stringify(chunk.split("\n")[0])}`,
+    );
+  });
+});

--- a/scripts/comment-sigma-results/test/splitCommentIntoChunks.test.js
+++ b/scripts/comment-sigma-results/test/splitCommentIntoChunks.test.js
@@ -1,0 +1,250 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { commentByteSize, splitCommentIntoChunks } from '../lib/comment-body.js';
+
+const TITLE = '### Sigma Rule Results';
+const CHANGED_HEADING = '### Changed Files';
+const DELETED_HEADING = '### Deleted Files';
+const RESULTS_HEADING = '### Test Results';
+const RESULTS_TABLE_HEADER = '| File name | Link | Result count | Execution time | Bytes processed | Errors |';
+const RESULTS_TABLE_SEPARATOR = '| --- | --- | --- | --- | --- | --- |';
+
+const changedFile = i => `- [rule_${i}.json](https://github.com/grafana/sigma-internal/blob/my-branch/rules/rule_${i}.json)`;
+const resultsRow = i => `| rule_${i}.json | [See in Explore](https://grafana.example/explore?left=abc) | 3 | - | - | 0 |`;
+const partLabel = (part, total) => `:open_book: Part ${part} of ${total}`;
+
+/** The room splitCommentIntoChunks keeps free in every chunk for its part label and the blank line below it. */
+const SAFETY_MARGIN = commentByteSize(`${partLabel(100, 100)}\n\n`);
+
+/** A comment shaped like the ones buildCommentBody renders, built here to keep the test isolated. */
+function buildComment() {
+  return [
+    '',
+    TITLE,
+    '',
+    '| Changed | Deleted |',
+    '| --- | --- |',
+    '| 20 | 1 |',
+    '',
+    CHANGED_HEADING,
+    '',
+    ...Array.from({ length: 20 }, (_, i) => changedFile(i)),
+    '',
+    DELETED_HEADING,
+    '',
+    '- rules/old_rule.json',
+    '',
+    RESULTS_HEADING,
+    '',
+    RESULTS_TABLE_HEADER,
+    RESULTS_TABLE_SEPARATOR,
+    ...Array.from({ length: 20 }, (_, i) => resultsRow(i)),
+    '',
+  ].join('\n');
+}
+
+/** Index of `line` in the comment. */
+function lineIndex(lines, line) {
+  const index = lines.indexOf(line);
+  assert(index !== -1, `line not found in the comment: ${line}`);
+  return index;
+}
+
+/** The byte limit that makes the comment split right before the line at `index`. */
+function limitSplittingBefore(lines, index) {
+  const bytesThroughLine = lines.slice(0, index + 1).reduce((total, line) => total + commentByteSize(line + '\n'), 0);
+  return bytesThroughLine - 1 + SAFETY_MARGIN;
+}
+
+/** Chunk content without the blank lines, which markdown ignores anyway. */
+const contentLines = chunk => chunk.split('\n').filter(line => line.trim() !== '');
+
+/** Chunk without its part label, to assert on the comment content alone. */
+const withoutPartLabel = chunk => chunk.split('\n').filter(line => !line.startsWith(':open_book: Part ')).join('\n');
+
+test('splitCommentIntoChunks - a split in the middle of a table repeats the table header', () => {
+  const comment = buildComment();
+  const lines = comment.split('\n');
+
+  const chunks = splitCommentIntoChunks(comment, limitSplittingBefore(lines, lineIndex(lines, resultsRow(2))));
+
+  // The first chunk keeps the table it started ...
+  assert(chunks[0].includes(`${RESULTS_TABLE_HEADER}\n${RESULTS_TABLE_SEPARATOR}\n${resultsRow(0)}`));
+  // ... and the second one repeats the header above the remaining rows
+  assert.deepStrictEqual(
+    contentLines(withoutPartLabel(chunks[1])).slice(0, 3),
+    [RESULTS_TABLE_HEADER, RESULTS_TABLE_SEPARATOR, resultsRow(2)],
+  );
+});
+
+test('splitCommentIntoChunks - a split right below a table header moves heading and header to the next chunk', () => {
+  const comment = buildComment();
+  const lines = comment.split('\n');
+
+  const chunks = splitCommentIntoChunks(comment, limitSplittingBefore(lines, lineIndex(lines, resultsRow(0))));
+
+  // An empty table head is worthless, so nothing of it stays behind in the first chunk
+  assert(!chunks[0].includes(RESULTS_HEADING));
+  assert(!chunks[0].includes(RESULTS_TABLE_HEADER));
+  assert(!chunks[0].includes(RESULTS_TABLE_SEPARATOR));
+  // Heading and table head lead the second chunk, followed by the first row
+  assert.deepStrictEqual(
+    contentLines(withoutPartLabel(chunks[1])).slice(0, 4),
+    [RESULTS_HEADING, RESULTS_TABLE_HEADER, RESULTS_TABLE_SEPARATOR, resultsRow(0)],
+  );
+});
+
+test('splitCommentIntoChunks - a split right after a heading moves the heading to the next chunk', () => {
+  const comment = buildComment();
+  const lines = comment.split('\n');
+  const heading = lineIndex(lines, DELETED_HEADING);
+
+  // Split before the blank line below the heading
+  const chunks = splitCommentIntoChunks(comment, limitSplittingBefore(lines, heading + 1));
+
+  assert(!chunks[0].includes(DELETED_HEADING));
+  assert.deepStrictEqual(contentLines(withoutPartLabel(chunks[1])).slice(0, 2), [DELETED_HEADING, '- rules/old_rule.json']);
+  assert(chunks[1].includes(`${DELETED_HEADING}\n\n`), `heading is not followed by a blank line: ${JSON.stringify(chunks[1])}`);
+});
+
+test('splitCommentIntoChunks - a split after the blank line below a heading moves both to the next chunk', () => {
+  const comment = buildComment();
+  const lines = comment.split('\n');
+  const heading = lineIndex(lines, DELETED_HEADING);
+
+  // Split before the first text line below the heading
+  const chunks = splitCommentIntoChunks(comment, limitSplittingBefore(lines, heading + 2));
+
+  assert(!chunks[0].includes(DELETED_HEADING));
+  assert.deepStrictEqual(contentLines(withoutPartLabel(chunks[1])).slice(0, 2), [DELETED_HEADING, '- rules/old_rule.json']);
+  assert(chunks[1].includes(`${DELETED_HEADING}\n\n`), `heading is not followed by a blank line: ${JSON.stringify(chunks[1])}`);
+});
+
+test('splitCommentIntoChunks - a comment below the limit is returned unsplit', () => {
+  const comment = buildComment();
+
+  const chunks = splitCommentIntoChunks(comment, commentByteSize(comment) * 2);
+
+  assert.strictEqual(chunks.length, 1);
+  assert.strictEqual(chunks[0], comment + '\n');
+});
+
+test('splitCommentIntoChunks - a comment of exactly the limit is not split, one byte more is', () => {
+  const comment = buildComment();
+  // The limit has to cover the comment plus the room reserved for a part label
+  const size = commentByteSize(comment + '\n') + SAFETY_MARGIN;
+
+  assert.strictEqual(splitCommentIntoChunks(comment, size).length, 1);
+  assert.strictEqual(splitCommentIntoChunks(comment, size - 1).length, 2);
+});
+
+test('splitCommentIntoChunks - the limit counts bytes, not characters', () => {
+  const comment = ['- ééééé', '- ééééé', '- ééééé'].join('\n');
+  assert.strictEqual(commentByteSize(comment + '\n'), 39);
+  assert.strictEqual((comment + '\n').length, 24);
+
+  // 30 characters would fit the whole comment, 30 bytes do not
+  assert(splitCommentIntoChunks(comment, 30 + SAFETY_MARGIN).length > 1);
+});
+
+test('splitCommentIntoChunks - an empty comment yields a single newline chunk', () => {
+  assert.deepStrictEqual(splitCommentIntoChunks('', 100), ['\n']);
+});
+
+test('splitCommentIntoChunks - a table spanning several chunks repeats the header in every one of them', () => {
+  const comment = buildComment();
+
+  const chunks = splitCommentIntoChunks(comment, 400);
+
+  const chunksWithRows = chunks.filter(chunk => chunk.includes('| rule_'));
+  assert(chunksWithRows.length > 2, `expected the table to span more than two chunks, got ${chunksWithRows.length}`);
+  for (const chunk of chunksWithRows) {
+    assert(
+      chunk.includes(`${RESULTS_TABLE_HEADER}\n${RESULTS_TABLE_SEPARATOR}`),
+      `chunk without a table header: ${JSON.stringify(chunk)}`,
+    );
+  }
+});
+
+test('splitCommentIntoChunks - no content is lost when splitting', () => {
+  const comment = buildComment();
+
+  const chunks = splitCommentIntoChunks(comment, 400);
+
+  const rejoined = contentLines(chunks.join(''));
+  for (const line of contentLines(comment)) {
+    assert(rejoined.includes(line), `line missing after splitting: ${line}`);
+  }
+});
+
+test('splitCommentIntoChunks - no chunk exceeds the limit, part label included', () => {
+  const comment = buildComment();
+
+  for (const chunk of splitCommentIntoChunks(comment, 400)) {
+    assert(commentByteSize(chunk) <= 400, `chunk of ${commentByteSize(chunk)} bytes exceeds the limit`);
+  }
+});
+
+test('splitCommentIntoChunks - text below a table does not inherit the table header', () => {
+  const comment = [
+    RESULTS_HEADING,
+    '',
+    RESULTS_TABLE_HEADER,
+    RESULTS_TABLE_SEPARATOR,
+    resultsRow(0),
+    '',
+    DELETED_HEADING,
+    '',
+    ...Array.from({ length: 6 }, (_, i) => `- rules/old_rule_${i}.json`),
+  ].join('\n');
+
+  const chunks = splitCommentIntoChunks(comment, 300);
+
+  assert(chunks.length > 1);
+  for (const chunk of chunks.filter(chunk => !chunk.includes('| rule_'))) {
+    assert(!chunk.includes(RESULTS_TABLE_SEPARATOR), `table header carried over into plain text: ${JSON.stringify(chunk)}`);
+  }
+});
+
+test('splitCommentIntoChunks - a single line above the limit ends up alone in its chunk', () => {
+  const longRow = resultsRow(0);
+  const comment = ['- rules/old_rule.json', longRow, '- rules/another_rule.json'].join('\n');
+  assert(commentByteSize(longRow + '\n') > 40);
+
+  const chunks = splitCommentIntoChunks(comment, 40);
+
+  // The line cannot be split any further, so it is passed through instead of being dropped
+  const chunkWithLongRow = chunks.find(chunk => chunk.includes(longRow));
+  assert.deepStrictEqual(contentLines(withoutPartLabel(chunkWithLongRow)), [longRow]);
+  assert(chunks.join('').includes('- rules/another_rule.json'));
+});
+
+test('splitCommentIntoChunks - a comment that is not split carries no part label', () => {
+  const comment = buildComment();
+
+  const chunks = splitCommentIntoChunks(comment, commentByteSize(comment) * 2);
+
+  assert.strictEqual(chunks.length, 1);
+  assert(!chunks[0].includes(':open_book: Part '), 'a single chunk should not be numbered');
+});
+
+test('splitCommentIntoChunks - every chunk is numbered with its part and the total', () => {
+  const comment = buildComment();
+
+  const chunks = splitCommentIntoChunks(comment, 400);
+  const total = chunks.length;
+
+  assert(total > 1);
+  // The first chunk is numbered at the end, every following one at the top
+  assert(chunks[0].endsWith(partLabel(1, total)), `first chunk ends with: ${JSON.stringify(chunks[0].slice(-40))}`);
+  for (let i = 1; i < total; i++) {
+    assert(
+      chunks[i].startsWith(`${partLabel(i + 1, total)}\n\n`),
+      `chunk ${i} starts with: ${JSON.stringify(chunks[i].slice(0, 40))}`,
+    );
+  }
+  // Exactly one label per chunk
+  for (const chunk of chunks) {
+    assert.strictEqual(chunk.split('\n').filter(line => line.startsWith(':open_book: Part ')).length, 1);
+  }
+});

--- a/scripts/comment-sigma-results/test/splitCommentIntoChunks.test.js
+++ b/scripts/comment-sigma-results/test/splitCommentIntoChunks.test.js
@@ -13,8 +13,12 @@ const changedFile = i => `- [rule_${i}.json](https://github.com/grafana/sigma-in
 const resultsRow = i => `| rule_${i}.json | [See in Explore](https://grafana.example/explore?left=abc) | 3 | - | - | 0 |`;
 const partLabel = (part, total) => `:open_book: Part ${part} of ${total}`;
 
-/** The room splitCommentIntoChunks keeps free in every chunk for its part label and the blank line below it. */
-const SAFETY_MARGIN = commentByteSize(`${partLabel(100, 100)}\n\n`);
+/** The value the workflow passes as COMMENT_IDENTIFIER, hidden at the top of every chunk. */
+const COMMENT_IDENTIFIER = 'Sigma Rule Conversions';
+const IDENTIFIER_MARKER = `<!-- ${COMMENT_IDENTIFIER} -->`;
+
+/** The room splitCommentIntoChunks keeps free in every chunk for its part label and identifier marker. */
+const SAFETY_MARGIN = commentByteSize(`${partLabel(100, 100)}\n\n${IDENTIFIER_MARKER}\n`);
 
 /** A comment shaped like the ones buildCommentBody renders, built here to keep the test isolated. */
 function buildComment() {
@@ -59,20 +63,22 @@ function limitSplittingBefore(lines, index) {
 /** Chunk content without the blank lines, which markdown ignores anyway. */
 const contentLines = chunk => chunk.split('\n').filter(line => line.trim() !== '');
 
-/** Chunk without its part label, to assert on the comment content alone. */
-const withoutPartLabel = chunk => chunk.split('\n').filter(line => !line.startsWith(':open_book: Part ')).join('\n');
+/** Chunk without the identifier marker and part label, to assert on the comment content alone. */
+const commentContent = chunk => chunk.split('\n')
+  .filter(line => !line.startsWith(':open_book: Part ') && line !== IDENTIFIER_MARKER)
+  .join('\n');
 
 test('splitCommentIntoChunks - a split in the middle of a table repeats the table header', () => {
   const comment = buildComment();
   const lines = comment.split('\n');
 
-  const chunks = splitCommentIntoChunks(comment, limitSplittingBefore(lines, lineIndex(lines, resultsRow(2))));
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, limitSplittingBefore(lines, lineIndex(lines, resultsRow(2))));
 
   // The first chunk keeps the table it started ...
   assert(chunks[0].includes(`${RESULTS_TABLE_HEADER}\n${RESULTS_TABLE_SEPARATOR}\n${resultsRow(0)}`));
   // ... and the second one repeats the header above the remaining rows
   assert.deepStrictEqual(
-    contentLines(withoutPartLabel(chunks[1])).slice(0, 3),
+    contentLines(commentContent(chunks[1])).slice(0, 3),
     [RESULTS_TABLE_HEADER, RESULTS_TABLE_SEPARATOR, resultsRow(2)],
   );
 });
@@ -81,7 +87,7 @@ test('splitCommentIntoChunks - a split right below a table header moves heading 
   const comment = buildComment();
   const lines = comment.split('\n');
 
-  const chunks = splitCommentIntoChunks(comment, limitSplittingBefore(lines, lineIndex(lines, resultsRow(0))));
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, limitSplittingBefore(lines, lineIndex(lines, resultsRow(0))));
 
   // An empty table head is worthless, so nothing of it stays behind in the first chunk
   assert(!chunks[0].includes(RESULTS_HEADING));
@@ -89,7 +95,7 @@ test('splitCommentIntoChunks - a split right below a table header moves heading 
   assert(!chunks[0].includes(RESULTS_TABLE_SEPARATOR));
   // Heading and table head lead the second chunk, followed by the first row
   assert.deepStrictEqual(
-    contentLines(withoutPartLabel(chunks[1])).slice(0, 4),
+    contentLines(commentContent(chunks[1])).slice(0, 4),
     [RESULTS_HEADING, RESULTS_TABLE_HEADER, RESULTS_TABLE_SEPARATOR, resultsRow(0)],
   );
 });
@@ -100,10 +106,10 @@ test('splitCommentIntoChunks - a split right after a heading moves the heading t
   const heading = lineIndex(lines, DELETED_HEADING);
 
   // Split before the blank line below the heading
-  const chunks = splitCommentIntoChunks(comment, limitSplittingBefore(lines, heading + 1));
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, limitSplittingBefore(lines, heading + 1));
 
   assert(!chunks[0].includes(DELETED_HEADING));
-  assert.deepStrictEqual(contentLines(withoutPartLabel(chunks[1])).slice(0, 2), [DELETED_HEADING, '- rules/old_rule.json']);
+  assert.deepStrictEqual(contentLines(commentContent(chunks[1])).slice(0, 2), [DELETED_HEADING, '- rules/old_rule.json']);
   assert(chunks[1].includes(`${DELETED_HEADING}\n\n`), `heading is not followed by a blank line: ${JSON.stringify(chunks[1])}`);
 });
 
@@ -113,20 +119,22 @@ test('splitCommentIntoChunks - a split after the blank line below a heading move
   const heading = lineIndex(lines, DELETED_HEADING);
 
   // Split before the first text line below the heading
-  const chunks = splitCommentIntoChunks(comment, limitSplittingBefore(lines, heading + 2));
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, limitSplittingBefore(lines, heading + 2));
 
   assert(!chunks[0].includes(DELETED_HEADING));
-  assert.deepStrictEqual(contentLines(withoutPartLabel(chunks[1])).slice(0, 2), [DELETED_HEADING, '- rules/old_rule.json']);
+  assert.deepStrictEqual(contentLines(commentContent(chunks[1])).slice(0, 2), [DELETED_HEADING, '- rules/old_rule.json']);
   assert(chunks[1].includes(`${DELETED_HEADING}\n\n`), `heading is not followed by a blank line: ${JSON.stringify(chunks[1])}`);
 });
 
 test('splitCommentIntoChunks - a comment below the limit is returned unsplit', () => {
   const comment = buildComment();
 
-  const chunks = splitCommentIntoChunks(comment, commentByteSize(comment) * 2);
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, commentByteSize(comment) * 2);
 
   assert.strictEqual(chunks.length, 1);
-  assert.strictEqual(chunks[0], comment + '\n');
+  // The identifier line sits flush above the comment, which is otherwise unchanged
+  assert(chunks[0].startsWith(`${IDENTIFIER_MARKER}\n${TITLE}\n`), `chunk starts with: ${JSON.stringify(chunks[0].slice(0, 60))}`);
+  assert.deepStrictEqual(contentLines(commentContent(chunks[0])), contentLines(comment));
 });
 
 test('splitCommentIntoChunks - a comment of exactly the limit is not split, one byte more is', () => {
@@ -134,8 +142,8 @@ test('splitCommentIntoChunks - a comment of exactly the limit is not split, one 
   // The limit has to cover the comment plus the room reserved for a part label
   const size = commentByteSize(comment + '\n') + SAFETY_MARGIN;
 
-  assert.strictEqual(splitCommentIntoChunks(comment, size).length, 1);
-  assert.strictEqual(splitCommentIntoChunks(comment, size - 1).length, 2);
+  assert.strictEqual(splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, size).length, 1);
+  assert.strictEqual(splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, size - 1).length, 2);
 });
 
 test('splitCommentIntoChunks - the limit counts bytes, not characters', () => {
@@ -144,17 +152,17 @@ test('splitCommentIntoChunks - the limit counts bytes, not characters', () => {
   assert.strictEqual((comment + '\n').length, 24);
 
   // 30 characters would fit the whole comment, 30 bytes do not
-  assert(splitCommentIntoChunks(comment, 30 + SAFETY_MARGIN).length > 1);
+  assert(splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 30 + SAFETY_MARGIN).length > 1);
 });
 
-test('splitCommentIntoChunks - an empty comment yields a single newline chunk', () => {
-  assert.deepStrictEqual(splitCommentIntoChunks('', 100), ['\n']);
+test('splitCommentIntoChunks - an empty comment yields just the identifier line', () => {
+  assert.deepStrictEqual(splitCommentIntoChunks('', COMMENT_IDENTIFIER, 100), [`${IDENTIFIER_MARKER}\n`]);
 });
 
 test('splitCommentIntoChunks - a table spanning several chunks repeats the header in every one of them', () => {
   const comment = buildComment();
 
-  const chunks = splitCommentIntoChunks(comment, 400);
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 400);
 
   const chunksWithRows = chunks.filter(chunk => chunk.includes('| rule_'));
   assert(chunksWithRows.length > 2, `expected the table to span more than two chunks, got ${chunksWithRows.length}`);
@@ -169,7 +177,7 @@ test('splitCommentIntoChunks - a table spanning several chunks repeats the heade
 test('splitCommentIntoChunks - no content is lost when splitting', () => {
   const comment = buildComment();
 
-  const chunks = splitCommentIntoChunks(comment, 400);
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 400);
 
   const rejoined = contentLines(chunks.join(''));
   for (const line of contentLines(comment)) {
@@ -180,7 +188,7 @@ test('splitCommentIntoChunks - no content is lost when splitting', () => {
 test('splitCommentIntoChunks - no chunk exceeds the limit, part label included', () => {
   const comment = buildComment();
 
-  for (const chunk of splitCommentIntoChunks(comment, 400)) {
+  for (const chunk of splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 400)) {
     assert(commentByteSize(chunk) <= 400, `chunk of ${commentByteSize(chunk)} bytes exceeds the limit`);
   }
 });
@@ -198,7 +206,7 @@ test('splitCommentIntoChunks - text below a table does not inherit the table hea
     ...Array.from({ length: 6 }, (_, i) => `- rules/old_rule_${i}.json`),
   ].join('\n');
 
-  const chunks = splitCommentIntoChunks(comment, 300);
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 300);
 
   assert(chunks.length > 1);
   for (const chunk of chunks.filter(chunk => !chunk.includes('| rule_'))) {
@@ -211,18 +219,18 @@ test('splitCommentIntoChunks - a single line above the limit ends up alone in it
   const comment = ['- rules/old_rule.json', longRow, '- rules/another_rule.json'].join('\n');
   assert(commentByteSize(longRow + '\n') > 40);
 
-  const chunks = splitCommentIntoChunks(comment, 40);
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 40);
 
   // The line cannot be split any further, so it is passed through instead of being dropped
   const chunkWithLongRow = chunks.find(chunk => chunk.includes(longRow));
-  assert.deepStrictEqual(contentLines(withoutPartLabel(chunkWithLongRow)), [longRow]);
+  assert.deepStrictEqual(contentLines(commentContent(chunkWithLongRow)), [longRow]);
   assert(chunks.join('').includes('- rules/another_rule.json'));
 });
 
 test('splitCommentIntoChunks - a comment that is not split carries no part label', () => {
   const comment = buildComment();
 
-  const chunks = splitCommentIntoChunks(comment, commentByteSize(comment) * 2);
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, commentByteSize(comment) * 2);
 
   assert.strictEqual(chunks.length, 1);
   assert(!chunks[0].includes(':open_book: Part '), 'a single chunk should not be numbered');
@@ -231,7 +239,7 @@ test('splitCommentIntoChunks - a comment that is not split carries no part label
 test('splitCommentIntoChunks - every chunk is numbered with its part and the total', () => {
   const comment = buildComment();
 
-  const chunks = splitCommentIntoChunks(comment, 400);
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 400);
   const total = chunks.length;
 
   assert(total > 1);
@@ -239,7 +247,7 @@ test('splitCommentIntoChunks - every chunk is numbered with its part and the tot
   assert(chunks[0].endsWith(partLabel(1, total)), `first chunk ends with: ${JSON.stringify(chunks[0].slice(-40))}`);
   for (let i = 1; i < total; i++) {
     assert(
-      chunks[i].startsWith(`${partLabel(i + 1, total)}\n\n`),
+      chunks[i].startsWith(`${IDENTIFIER_MARKER}\n${partLabel(i + 1, total)}\n\n`),
       `chunk ${i} starts with: ${JSON.stringify(chunks[i].slice(0, 40))}`,
     );
   }


### PR DESCRIPTION
After a comment has been constructed it chunks into parts that dont exceed the github commit size limit (in bytes for utf-8 encoding). It also accounts for table headers and headlines so that these dont stand alone etc.

Part indication is added at the bottom/top of chunks aswell.

closes #348 