### PR TITLE
Improve deployment error reporting

### DIFF
--- a/actions/deploy/README.md
+++ b/actions/deploy/README.md
@@ -26,11 +26,12 @@ A fresh deployment (`fresh_deploy`) will delete all existing alert rules in the 
 
 ## Outputs
 
-| Name             | Description                                                                |
-| ---------------- | -------------------------------------------------------------------------- |
-| `alerts_created` | List of the UIDs of the alerts created during deployment (space-separated) |
-| `alerts_updated` | List of the UIDs of the alerts updated during deployment (space-separated) |
-| `alerts_deleted` | List of the UIDs of the alerts deleted during deployment (space-separated) |
+| Name               | Description                                                                |
+| ------------------ | -------------------------------------------------------------------------- |
+| `alerts_created`   | List of the UIDs of the alerts created during deployment (space-separated) |
+| `alerts_updated`   | List of the UIDs of the alerts updated during deployment (space-separated) |
+| `alerts_deleted`   | List of the UIDs of the alerts deleted during deployment (space-separated) |
+| `deployment_error` | Error reported by the deployer when the action fails                       |
 
 ## Usage
 

--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -29,6 +29,9 @@ outputs:
   alerts_deleted:
     description: "List of alerts UIDs deleted in Grafana"
     value: ${{ steps.output.outputs.alerts_deleted }}
+  deployment_error:
+    description: "Error reported by the deployer"
+    value: ${{ steps.output.outputs.deployment_error }}
 
 runs:
   using: "composite"
@@ -71,10 +74,11 @@ runs:
         COPIED_FILES: ${{ steps.changed-files.outputs.copied_files }}
         IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
       run: |
+        rm -f .sigma-deploy-output
         docker run --rm \
             -v "$(pwd):/sigma-rules" \
             -w /sigma-rules \
-            -e GITHUB_OUTPUT="/sigma-rules/github-output" \
+            -e GITHUB_OUTPUT="/sigma-rules/.sigma-deploy-output" \
             -e CONFIG_PATH="$CONFIG_PATH" \
             -e DEPLOYER_GRAFANA_SA_TOKEN="$GRAFANA_SA_TOKEN" \
             -e DEPLOYER_FRESH_DEPLOY="$FRESH_DEPLOY" \
@@ -85,10 +89,14 @@ runs:
             "ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:$IMAGE_REF" \
             deploy
     - name: Move Output
+      if: ${{ always() }}
       id: output
       shell: bash
       run: |
-        mv github-output $GITHUB_OUTPUT
+        if [[ -f .sigma-deploy-output ]]; then
+          cat .sigma-deploy-output >> "$GITHUB_OUTPUT"
+          rm -f .sigma-deploy-output
+        fi
     - name: Get Grafana Instance
       if: success() && github.event_name == 'push'
       id: grafana-instance
@@ -160,8 +168,19 @@ runs:
     - name: Comment Status
       if: failure() && github.event_name == 'push'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        DEPLOYMENT_ERROR: ${{ steps.output.outputs.deployment_error }}
       with:
           script: |
+            const deploymentError = process.env.DEPLOYMENT_ERROR?.trim();
+            const escapedError = deploymentError
+              ?.replaceAll("&", "&amp;")
+              .replaceAll("<", "&lt;")
+              .replaceAll(">", "&gt;");
+            const body = escapedError
+              ? `## Sigma Rule Deployment Failed\n\nThe deployer reported:\n\n<pre>${escapedError}</pre>`
+              : "## Sigma Rule Deployment Failed";
+
             const associatedPrs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -172,10 +191,10 @@ runs:
               for (const pr of associatedPrs.data) {
                 const nodeId = pr.node_id;
 
-                const query = `mutation AddComment {
+                const query = `mutation AddComment($body: String!, $subjectId: ID!) {
                 addComment(input: {
-                  body: "Sigma Rules Deployment Failed",
-                  subjectId: "${nodeId}",
+                  body: $body,
+                  subjectId: $subjectId,
                 }) {
                   subject {
                     id
@@ -186,6 +205,11 @@ runs:
                 }
                 }`
 
-                await github.graphql(query);
+                const variables = {
+                  body: body,
+                  subjectId: nodeId,
+                };
+
+                await github.graphql(query, variables);
               }
             }

--- a/cmd/sigma-deployer/main.go
+++ b/cmd/sigma-deployer/main.go
@@ -4,12 +4,27 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/grafana/sigma-rule-deployment/internal/deploy"
 	"github.com/grafana/sigma-rule-deployment/internal/integrate"
 	"github.com/grafana/sigma-rule-deployment/internal/querytest"
+	"github.com/grafana/sigma-rule-deployment/shared"
 )
+
+func reportDeploymentError(prefix string, err error) {
+	message := fmt.Sprintf("%s: %v", prefix, err)
+	message = strings.NewReplacer("\r", " ", "\n", " ").Replace(message)
+	fmt.Println(message)
+
+	if os.Getenv("GITHUB_OUTPUT") == "" {
+		return
+	}
+	if outputErr := shared.SetOutput("deployment_error", message); outputErr != nil {
+		fmt.Printf("Error writing deployment error output: %v\n", outputErr)
+	}
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -67,7 +82,7 @@ func main() {
 		deployer := deploy.NewDeployer()
 
 		if err := deployer.LoadConfig(ctx); err != nil {
-			fmt.Printf("Error loading config: %v\n", err)
+			reportDeploymentError("Error loading config", err)
 			os.Exit(1)
 		}
 
@@ -80,7 +95,7 @@ func main() {
 			err = deployer.ConfigNormalMode()
 		}
 		if err != nil {
-			fmt.Printf("Error configuring deployment: %v\n", err)
+			reportDeploymentError("Error configuring deployment", err)
 			os.Exit(1)
 		}
 
@@ -89,14 +104,14 @@ func main() {
 
 		// Write action outputs
 		if err := deployer.WriteOutput(alertsCreated, alertsUpdated, alertsDeleted); err != nil {
-			fmt.Printf("Error writing output: %v\n", err)
+			reportDeploymentError("Error writing output", err)
 			os.Exit(1)
 		}
 
 		// We only check the deployment error AFTER writing the output so that
 		// we still report the alerts that were created, updated and deleted before the error
 		if errDeploy != nil {
-			fmt.Printf("Error deploying: %v\n", errDeploy)
+			reportDeploymentError("Error deploying", errDeploy)
 			os.Exit(1)
 		}
 	default:

--- a/cmd/sigma-deployer/main_test.go
+++ b/cmd/sigma-deployer/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReportDeploymentErrorWritesSingleLineOutput(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "github-output")
+	t.Setenv("GITHUB_OUTPUT", outputPath)
+
+	reportDeploymentError("Error deploying", errors.New("first line\nsecond line"))
+
+	contents, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const expected = "deployment_error=Error deploying: first line second line\n"
+	if string(contents) != expected {
+		t.Fatalf("unexpected output:\nwant: %q\n got: %q", expected, contents)
+	}
+}

--- a/scripts/comment-sigma-results/lib/tables.js
+++ b/scripts/comment-sigma-results/lib/tables.js
@@ -23,7 +23,23 @@ export function buildTestResultsTable(testResults) {
         ? `${result.stats.bytesProcessed.value.toLocaleString()} ${result.stats.bytesProcessed.unit}`.trim()
         : '-';
       const linkCell = result.link ? `[See in Explore](${result.link})` : '-';
-      resultTable += `| ${title} | ${linkCell} | ${result.stats.count} | ${executionTime} | ${bytesProcessed} | ${result.stats.errors.length} |\n`;
+      const errors = result.stats.errors || [];
+      const errorCell = errors.length === 0
+        ? '0'
+        : `${errors.length}<br>${errors
+          .map(error => String(error).replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>'))
+          .join('<br>')}`;
+
+      if (process.env.GITHUB_ACTIONS) {
+        for (const error of errors) {
+          core.error(String(error), {
+            title: `Integration Error in ${title}`,
+            file: filePath,
+          });
+        }
+      }
+
+      resultTable += `| ${title} | ${linkCell} | ${result.stats.count} | ${executionTime} | ${bytesProcessed} | ${errorCell} |\n`;
     }
   }
 

--- a/scripts/comment-sigma-results/test/buildTestResultsTable.test.js
+++ b/scripts/comment-sigma-results/test/buildTestResultsTable.test.js
@@ -2,6 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import * as commentModule from '../comment.js';
 
+// Avoid emitting GitHub Actions annotations while testing table rendering.
+delete process.env.GITHUB_ACTIONS;
+
 test('buildTestResultsTable - empty object returns empty string', () => {
   const result = commentModule.buildTestResultsTable({});
   assert.strictEqual(result, '');
@@ -155,7 +158,29 @@ test('buildTestResultsTable - handles errors array correctly', () => {
   assert(result.includes('file1.json'));
   assert(result.includes('https://grafana.com/explore/123'));
   assert(result.includes('0'));
-  assert(result.includes('3')); // error count
+  assert(result.includes('3<br>error1<br>error2<br>error3'));
+});
+
+test('buildTestResultsTable - keeps integration errors inside one table cell', () => {
+  const testResults = {
+    '/path/to/file1.json': [
+      {
+        datasource: 'loki',
+        link: 'https://grafana.com/explore/123',
+        stats: {
+          count: 0,
+          errors: ['parse error | unexpected token\nline 2'],
+          fields: {}
+        }
+      }
+    ]
+  };
+
+  const result = commentModule.buildTestResultsTable(testResults);
+
+  assert(result.includes('1<br>parse error \\| unexpected token<br>line 2'));
+  const dataLines = result.split('\n').filter(line => line.includes('file1.json'));
+  assert.strictEqual(dataLines.length, 1);
 });
 
 test('buildTestResultsTable - displays execution time and bytes processed when provided', () => {
@@ -240,4 +265,3 @@ test('buildTestResultsTable - displays zero values when present, shows dash when
   const dataLineMissing = linesMissing.find(line => line.includes('file2.json'));
   assert(dataLineMissing.includes('-'), 'Should show dash for missing fields');
 });
-


### PR DESCRIPTION
## What changed

Integration test errors now appear directly in the results table and as GitHub Actions annotations. Deployment failures are exposed through a dedicated action output and included in the pull request comment with HTML escaping.

The action documentation and regression coverage have been updated for both paths.

Closes #357

## Testing

- `go test ./...`
- `golangci-lint run --timeout=5m`
- `npm test` with Node.js 24: 51 tests passed
- Parsed `actions/deploy/action.yml` with yq
- Checked the embedded GitHub Script with Node.js