### PR TITLE
Fix failing convert action

### DIFF
--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -142,7 +142,11 @@ runs:
       id: set-output
       shell: bash
       run: |
-        mv github-output $GITHUB_OUTPUT
+        # The converter only creates this file when there are conversion errors to report.
+        if [ -f github-output ]; then
+          cat github-output >> "$GITHUB_OUTPUT"
+          rm github-output
+        fi
 
 
     - name: Comment Conversions


### PR DESCRIPTION
In succesful runs github-output file was never created resulting in a failure when it was tried to be moved. Made it more robust now.