### PR TITLE
Track config changes in convert and track dropped rules

### DIFF
--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -150,6 +150,8 @@ runs:
 
     - name: Cleanup old config file
       id: cleanup-old-config
+      env: 
+        CONFIG_PATH: ${{ inputs.config_path }}
       shell: bash
       run: |
         if [ -f ${CONFIG_PATH}.old ]; then

--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -116,7 +116,7 @@ runs:
         PREVIOUS_REF: ${{ steps.commits.outputs.previous-ref }}
       run: |
         # Load the old config from the previous commit
-        git show "${PREVIOUS_REF}:${CONFIG_PATH}" > ${CONFIG_PATH}.old.yml || echo "No previous config found"
+        git show "${PREVIOUS_REF}:${CONFIG_PATH}" > "${CONFIG_PATH}.old.yml" || echo "No previous config found"
 
     - name: Run Sigma Rule Converter
       id: convert
@@ -154,8 +154,8 @@ runs:
         CONFIG_PATH: ${{ inputs.config_path }}
       shell: bash
       run: |
-        if [ -f ${CONFIG_PATH}.old.yml ]; then
-          rm -f ${CONFIG_PATH}.old.yml
+        if [ -f "${CONFIG_PATH}.old.yml" ]; then
+          rm -f "${CONFIG_PATH}.old.yml"
         fi
 
     - name: Set output

--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -116,7 +116,7 @@ runs:
         PREVIOUS_REF: ${{ steps.commits.outputs.previous-ref }}
       run: |
         # Load the old config from the previous commit
-        git show "${PREVIOUS_REF}:${CONFIG_PATH}" > ${CONFIG_PATH}.old || echo "No previous config found"
+        git show "${PREVIOUS_REF}:${CONFIG_PATH}" > ${CONFIG_PATH}.old.yml || echo "No previous config found"
 
     - name: Run Sigma Rule Converter
       id: convert
@@ -154,8 +154,8 @@ runs:
         CONFIG_PATH: ${{ inputs.config_path }}
       shell: bash
       run: |
-        if [ -f ${CONFIG_PATH}.old ]; then
-          rm -f ${CONFIG_PATH}.old
+        if [ -f ${CONFIG_PATH}.old.yml ]; then
+          rm -f ${CONFIG_PATH}.old.yml
         fi
 
     - name: Set output

--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -108,6 +108,16 @@ runs:
         REPO_ROOT="$(cd "$GITHUB_ACTION_PATH/../.." && pwd)"
         "$REPO_ROOT/scripts/determine-image-ref/determine-image-ref.sh" "$ACTION_REF"
 
+    - name: Load old config
+      id: load-old-config
+      shell: bash
+      env:
+        CONFIG_PATH: ${{ inputs.config_path }}
+        PREVIOUS_REF: ${{ steps.commits.outputs.previous-ref }}
+      run: |
+        # Load the old config from the previous commit
+        git show "${PREVIOUS_REF}:${CONFIG_PATH}" > ${CONFIG_PATH}.old || echo "No previous config found"
+
     - name: Run Sigma Rule Converter
       id: convert
       shell: bash
@@ -138,6 +148,14 @@ runs:
             "ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:$IMAGE_REF" \
             convert
 
+    - name: Cleanup old config file
+      id: cleanup-old-config
+      shell: bash
+      run: |
+        if [ -f ${CONFIG_PATH}.old ]; then
+          rm -f ${CONFIG_PATH}.old
+        fi
+
     - name: Set output
       id: set-output
       shell: bash
@@ -147,7 +165,6 @@ runs:
           cat github-output >> "$GITHUB_OUTPUT"
           rm github-output
         fi
-
 
     - name: Comment Conversions
       id: comment-conversions

--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -71,6 +71,7 @@ def convert_rules(
     changed_files: str = "",
     deleted_files: str = "",
     manual_files: str = "",
+    previous_config: Dynaconf | None = None,
 ) -> None:
     """Convert Sigma rules to the target format per each file in the conversions object
     in the config. The converted files will be saved in the PATH_PREFIX/conversions
@@ -122,6 +123,7 @@ def convert_rules(
         ValueError: Pipeline file path must be relative to the project root.
         ValueError: Error loading rule file {rule_file}.
     """
+    # region 1. Setup & validation
     changed_files_set = set(
         path_prefix / Path(x) for x in changed_files.split(" ") if x
     )
@@ -160,7 +162,9 @@ def convert_rules(
 
     # Create the output directory if it doesn't exist
     conversions_output_dir.mkdir(parents=True, exist_ok=True)
+    # endregion
 
+    # region 2. Load conversion defaults
     # Get top-level default values
     default_target = config.get("conversion_defaults.target", "loki")
     default_format = config.get("conversion_defaults.format", "default")
@@ -179,7 +183,9 @@ def convert_rules(
     default_json_indent = config.get("conversion_defaults.json_indent", 0)
     default_required_rule_fields = config.get("conversion_defaults.required_rule_fields", [])
     verbose = config.get("verbose", False)
+    # endregion
 
+    # region 3. Backfill manual flag
     # Backfill the manual flag onto conversion files a human modified since the last
     # automation commit. Doing this before the conversion loop means the freshly-added
     # flag is honoured (and the file preserved) on this same run.
@@ -195,9 +201,23 @@ def convert_rules(
         existing[MANUAL_KEY] = True
         _write_output(manual_file, existing, pretty_print, default_encoding)
         print(f"Marking manually-modified conversion file as manual: {manual_file}")
+    # endregion
+
+    changed_conversions = []
+
+    # Determine if the config file itself changed, and if so, check for conversion groups whose own config changed. Or if any global setting changed, requiring a full conversion.
+    config_path = config._loaded_files[0] if config._loaded_files else None
+    config_file_changed = config_path is not None and Path(config_path) in changed_files_set
+    if config_file_changed:
+        print(f"Config file {config_path} changed, checking for conversion groups whose own config changed")
+        all_config_changed, changed_conversions_list = get_config_changes(previous_config, config) if previous_config else (False, [])
+        all_rules = all_rules or all_config_changed
+        changed_conversions = changed_conversions_list
+        print(f"Changed conversion groups in config: {changed_conversions}")
 
     conversions_to_delete = []
     conversion_errors = []
+    # region 4. Per-conversion loop
     # Convert Sigma rules to the target format per each conversion object in the config
     for conversion in config.get("conversions", []):
         # If the conversion name is not unique, we'll overwrite the output file,
@@ -267,6 +287,29 @@ def convert_rules(
                 f"No files matched the patterns after applying file_pattern: {file_pattern}"
             )
 
+        # A rule dropped from (or reassigned away from) this conversion's own
+        # input list, with the file left in place on disk, needs its stale
+        # output cleaned up here
+        if config_file_changed and previous_config is not None:
+            prev_conversion = next(
+                (
+                    c
+                    for c in previous_config.get("conversions", [])
+                    if c.get("name") == name
+                ),
+                None,
+            )
+            for dropped_file in get_dropped_input_files(
+                prev_conversion, input_patterns, path_prefix, filtered_files
+            ):
+                rel_dropped_path = Path(dropped_file).relative_to(path_prefix)
+                output_filename = f"{name}_{rel_dropped_path.stem}.json".replace(
+                    os.sep, "_"
+                )
+                output_path = conversions_output_dir / output_filename
+                if output_path.exists():
+                    conversions_to_delete.append(output_path)
+
         print(f"Total files: {len(filtered_files)}")
         print(f"Target backend: {conversion.get('target', default_target)}")
         if all_rules:
@@ -292,6 +335,7 @@ def convert_rules(
             else:
                 pipelines.append(f"--pipeline={pipeline}")
 
+        # region 4.a Per-input-file conversion
         for input_file in filtered_files:
             # If we're not converting all rules, skip the conversion if:
             # - the file is not in the list of changed files
@@ -300,6 +344,7 @@ def convert_rules(
                 not all_rules
                 and Path(input_file) not in changed_files_set
                 and not any_pipeline_changed
+                and not name in changed_conversions
             ):
                 print(
                     f"Skipping conversion of {input_file} because it and it's pipelines haven't changed"
@@ -431,9 +476,12 @@ def convert_rules(
 
                 print(f"Output written to {output_file}")
                 print(f"Converting {name} completed with exit code {result.exit_code}")
+        # endregion
 
         print("-" * 80)
+    # endregion
 
+    # region 5. Cleanup deleted rules
     # Remove conversions of deleted rules from the output directory
     if len(conversions_to_delete) > 0:
         print("Removing conversions of deleted rules from the output directory")
@@ -446,7 +494,9 @@ def convert_rules(
                     continue
                 print(f"Removing {deleted_file}")
                 os.remove(deleted_file)
+    # endregion
 
+    # region 6. Report errors to GitHub Actions
     # If there were any conversion errors, send them to $GITHUB_OUTPUT for the GitHub Actions workflow to pick up and display in the UI.
     if conversion_errors:
         github_output_path = os.getenv("GITHUB_OUTPUT")
@@ -455,6 +505,7 @@ def convert_rules(
                 f.write(f"conversion_errors={json.dumps(conversion_errors).decode('utf-8')}\n")
         else:
             print("GITHUB_OUTPUT environment variable not set, cannot write conversion errors to GitHub Actions output")
+    # endregion
 
 
 def is_safe_path(base_dir: str | Path, target_path: str | Path) -> bool:
@@ -538,3 +589,78 @@ def filter_rule_fields(rule_dicts: list[dict[str, Any]], desired_fields: list[st
         necessary_fields = set(["id", "title"] + desired_fields)
 
     return [dict((field, rule_dict[field]) for field in necessary_fields if field in rule_dict) for rule_dict in rule_dicts]
+
+def get_config_changes(previous_config: Dynaconf, current_config: Dynaconf) -> tuple[bool, list[str]]:
+    """Get the list of conversion names whose own config block changed.
+
+    Args:
+        previous_config (Dynaconf): The previous config object.
+        current_config (Dynaconf): The current config object.
+
+    Returns:
+        tuple[bool, list[str]]: A tuple containing a boolean indicating if a global config setting changed and a list of conversion names whose config changed.
+    """
+    global_config_changed = False
+    # Check if any global config settings changed (except for conversions)
+    for key in current_config.keys():
+        if key != "conversions" and (key not in previous_config or current_config[key] != previous_config[key]):
+            global_config_changed = True
+            break
+
+    changed_conversions = []
+    for conversion in current_config.get("conversions", []):
+        name = conversion.get("name", None)
+        if not name:
+            continue
+        prev_conversion = next(
+            (c for c in previous_config.get("conversions", []) if c.get("name") == name),
+            None,
+        )
+        if prev_conversion is None or conversion != prev_conversion:
+            changed_conversions.append(name)
+    return global_config_changed, changed_conversions
+
+
+def _normalize_patterns(value: list | str | None) -> list[str]:
+    """Normalize a conversion's `input` value to a list of pattern strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return list(value)
+
+
+def get_dropped_input_files(
+    previous_conversion: dict | None,
+    current_input_patterns: list[str],
+    path_prefix: Path,
+    filtered_files: list[str],
+) -> list[str]:
+    """Resolve the files a conversion no longer matches because a pattern was
+    dropped from its `input` list since previous_config.
+
+    A pattern that was only narrowed, rather than dropped outright, still
+    counts as "removed" here since its exact string is gone from the current
+    list.
+    """
+    if previous_conversion is None:
+        return []
+
+    removed_patterns = [
+        pattern
+        for pattern in _normalize_patterns(previous_conversion.get("input"))
+        if pattern not in current_input_patterns
+    ]
+    if not removed_patterns:
+        return []
+
+    still_valid = set(filtered_files)
+    dropped_files = []
+    seen = set()
+    for pattern in removed_patterns:
+        for resolved in glob.glob(str(path_prefix / pattern), recursive=True):
+            if resolved in still_valid or resolved in seen:
+                continue
+            seen.add(resolved)
+            dropped_files.append(resolved)
+    return dropped_files

--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -123,7 +123,7 @@ def convert_rules(
         ValueError: Pipeline file path must be relative to the project root.
         ValueError: Error loading rule file {rule_file}.
     """
-    # region 1. Setup & validation
+
     changed_files_set = set(
         path_prefix / Path(x) for x in changed_files.split(" ") if x
     )
@@ -162,9 +162,8 @@ def convert_rules(
 
     # Create the output directory if it doesn't exist
     conversions_output_dir.mkdir(parents=True, exist_ok=True)
-    # endregion
 
-    # region 2. Load conversion defaults
+
     # Get top-level default values
     default_target = config.get("conversion_defaults.target", "loki")
     default_format = config.get("conversion_defaults.format", "default")
@@ -183,9 +182,7 @@ def convert_rules(
     default_json_indent = config.get("conversion_defaults.json_indent", 0)
     default_required_rule_fields = config.get("conversion_defaults.required_rule_fields", [])
     verbose = config.get("verbose", False)
-    # endregion
 
-    # region 3. Backfill manual flag
     # Backfill the manual flag onto conversion files a human modified since the last
     # automation commit. Doing this before the conversion loop means the freshly-added
     # flag is honoured (and the file preserved) on this same run.
@@ -201,7 +198,6 @@ def convert_rules(
         existing[MANUAL_KEY] = True
         _write_output(manual_file, existing, pretty_print, default_encoding)
         print(f"Marking manually-modified conversion file as manual: {manual_file}")
-    # endregion
 
     changed_conversions = []
 
@@ -217,7 +213,7 @@ def convert_rules(
 
     conversions_to_delete = []
     conversion_errors = []
-    # region 4. Per-conversion loop
+
     # Convert Sigma rules to the target format per each conversion object in the config
     for conversion in config.get("conversions", []):
         # If the conversion name is not unique, we'll overwrite the output file,
@@ -300,7 +296,7 @@ def convert_rules(
                 None,
             )
             for dropped_file in get_dropped_input_files(
-                prev_conversion, input_patterns, path_prefix, filtered_files
+                prev_conversion, input_patterns, path_prefix, filtered_files, file_pattern
             ):
                 rel_dropped_path = Path(dropped_file).relative_to(path_prefix)
                 output_filename = f"{name}_{rel_dropped_path.stem}.json".replace(
@@ -335,7 +331,6 @@ def convert_rules(
             else:
                 pipelines.append(f"--pipeline={pipeline}")
 
-        # region 4.a Per-input-file conversion
         for input_file in filtered_files:
             # If we're not converting all rules, skip the conversion if:
             # - the file is not in the list of changed files
@@ -476,12 +471,9 @@ def convert_rules(
 
                 print(f"Output written to {output_file}")
                 print(f"Converting {name} completed with exit code {result.exit_code}")
-        # endregion
 
         print("-" * 80)
-    # endregion
 
-    # region 5. Cleanup deleted rules
     # Remove conversions of deleted rules from the output directory
     if len(conversions_to_delete) > 0:
         print("Removing conversions of deleted rules from the output directory")
@@ -494,9 +486,7 @@ def convert_rules(
                     continue
                 print(f"Removing {deleted_file}")
                 os.remove(deleted_file)
-    # endregion
 
-    # region 6. Report errors to GitHub Actions
     # If there were any conversion errors, send them to $GITHUB_OUTPUT for the GitHub Actions workflow to pick up and display in the UI.
     if conversion_errors:
         github_output_path = os.getenv("GITHUB_OUTPUT")
@@ -505,7 +495,6 @@ def convert_rules(
                 f.write(f"conversion_errors={json.dumps(conversion_errors).decode('utf-8')}\n")
         else:
             print("GITHUB_OUTPUT environment variable not set, cannot write conversion errors to GitHub Actions output")
-    # endregion
 
 
 def is_safe_path(base_dir: str | Path, target_path: str | Path) -> bool:
@@ -635,6 +624,7 @@ def get_dropped_input_files(
     current_input_patterns: list[str],
     path_prefix: Path,
     filtered_files: list[str],
+    file_pattern: str
 ) -> list[str]:
     """Resolve the files a conversion no longer matches because a pattern was
     dropped from its `input` list since previous_config.
@@ -663,4 +653,5 @@ def get_dropped_input_files(
                 continue
             seen.add(resolved)
             dropped_files.append(resolved)
-    return dropped_files
+    # Finally exclude any files that dont match file pattern anyways
+    return [file for file in dropped_files if fnmatch.fnmatch(file, file_pattern)]

--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -344,7 +344,7 @@ def convert_rules(
                 not all_rules
                 and Path(input_file) not in changed_files_set
                 and not any_pipeline_changed
-                and not name in changed_conversions
+                and name not in changed_conversions
             ):
                 print(
                     f"Skipping conversion of {input_file} because it and it's pipelines haven't changed"

--- a/actions/convert/convert.py
+++ b/actions/convert/convert.py
@@ -602,8 +602,8 @@ def get_config_changes(previous_config: Dynaconf, current_config: Dynaconf) -> t
     """
     global_config_changed = False
     # Check if any global config settings changed (except for conversions)
-    for key in current_config.keys():
-        if key != "conversions" and (key not in previous_config or current_config[key] != previous_config[key]):
+    for key in ["conversion_defaults", "folders", "verbose"]:
+        if current_config.get(key) != previous_config.get(key):
             global_config_changed = True
             break
 

--- a/actions/convert/main.py
+++ b/actions/convert/main.py
@@ -8,6 +8,7 @@ usage: main.py [-h] [--config CONFIG] [--path-prefix PATH_PREFIX]
                [--pretty-print PRETTY_PRINT] [--all-rules ALL_RULES]
                [--changed-files CHANGED_FILES]
                [--deleted-files DELETED_FILES]
+               [--manual-files MANUAL_FILES]
 
 Sigma CLI Conversion
 
@@ -26,6 +27,9 @@ options:
                         List of changed files (default: )
   --deleted-files DELETED_FILES
                         List of deleted files (default: )
+  --manual-files MANUAL_FILES
+                        List of conversion files a human modified since the
+                        last automation commit (default: )
 ---
 Notes:
   - The path prefix must be set using the PATH_PREFIX environment variable,
@@ -57,10 +61,16 @@ if __name__ == "__main__":
     # Load config file and parse it using Dynaconf
     config = load_config(str(config_file))
 
+    previous_config = None
+    prev_config_file = Path(args.path_prefix) / Path(args.config + ".old")
+    if prev_config_file.exists():
+        previous_config = load_config(str(prev_config_file))
+
     # Convert Sigma rules to the target format per each file in the conversions object
     # in the config
     convert_rules(
         config=config,
+        previous_config=previous_config,
         path_prefix=args.path_prefix,
         render_traceback=args.render_traceback,
         pretty_print=args.pretty_print,

--- a/actions/convert/main.py
+++ b/actions/convert/main.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     config = load_config(str(config_file))
 
     previous_config = None
-    prev_config_file = Path(args.path_prefix) / Path(args.config + ".old")
+    prev_config_file = Path(args.path_prefix) / Path(args.config + ".old.yml")
     if prev_config_file.exists():
         previous_config = load_config(str(prev_config_file))
 

--- a/actions/convert/test_convert.py
+++ b/actions/convert/test_convert.py
@@ -1294,7 +1294,7 @@ def test_convert_rules_skips_manual_conversion(temp_workspace, mock_config):
     assert output_file.read_text() == manual_content
 
 
-def test_convert_rules_backfills_manual_flag(temp_workspace, mock_config):
+def test_convert_rules_backfills_manual_flag(temp_workspace, mock_config): # trufflehog:ignore
     """A human-modified conversion file listed in manual_files gains the manual flag."""
     conversion_dir = temp_workspace / "conversions"
     conversion_dir.mkdir()

--- a/actions/convert/test_convert.py
+++ b/actions/convert/test_convert.py
@@ -59,6 +59,37 @@ def mock_config_with_correlation_rule():
 
 
 @pytest.fixture
+def mock_config_two_groups():
+    """Mock configuration object with two independent conversion groups."""
+    return DynaconfDict(
+        {
+            "conversion_defaults": {
+                "target": "loki",
+                "format": "default",
+                "skip_unsupported": "true",
+                "file_pattern": "*.yml",
+            },
+            "conversions": [
+                {
+                    "name": "group_a",
+                    "input": ["rules/*.yml"],
+                    "target": "loki",
+                    "format": "default",
+                },
+                {
+                    "name": "group_b",
+                    "input": ["rules/*.yml"],
+                    # A different but genuinely installed backend, so a real
+                    # sigma-cli invocation for this group actually succeeds.
+                    "target": "text_query_test",
+                    "format": "default",
+                },
+            ],
+        }
+    )
+
+
+@pytest.fixture
 def temp_workspace(tmp_path):
     """Create a temporary workspace with a rules directory."""
     workspace = tmp_path / "workspace"
@@ -1407,3 +1438,475 @@ def test_convert_rules_skips_manual_before_conversion(
 
     # The skip happens before conversion, so sigma-cli is never invoked.
     mock_invoke.assert_not_called()
+
+
+####
+# Config file changes tests
+####
+
+def test_convert_rules_config_change_reconverts_group(temp_workspace, mock_config):
+    """A conversion group whose own config block changed is fully reconverted,
+    even though none of its rule files are in changed_files."""
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(mock_config["conversion_defaults"]),
+            "conversions": [
+                {
+                    "name": "test_conversion",
+                    "input": ["rules/*.yml"],
+                    "target": "splunk",
+                    "format": "default",
+                }
+            ],
+        }
+    )
+    # The config-change check is gated on the config file's own path appearing in
+    # changed_files, mirroring how the real action includes CONFIG_PATH in its diff.
+    mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    output_file = temp_workspace / "conversions" / "test_conversion_test.json"
+    assert output_file.exists()
+
+
+def test_convert_rules_renamed_group_converts_without_deleting_old(
+    temp_workspace, mock_config
+):
+    """A renamed conversion group is converted under its new name; the old
+    output file is left alone (its cleanup is the integrator's job, not the
+    converter's)."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    old_output_file = conversion_dir / "old_name_test.json"
+    old_output_file.write_text(
+        json.dumps({"conversion_name": "old_name"}).decode("utf-8")
+    )
+
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(mock_config["conversion_defaults"]),
+            "conversions": [
+                {
+                    "name": "old_name",
+                    "input": ["rules/*.yml"],
+                    "target": "loki",
+                    "format": "default",
+                }
+            ],
+        }
+    )
+    mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    new_output_file = conversion_dir / "test_conversion_test.json"
+    assert new_output_file.exists()
+    assert old_output_file.exists()
+    assert json.loads(old_output_file.read_bytes()) == {"conversion_name": "old_name"}
+
+
+def test_convert_rules_unrelated_group_not_reconverted_on_config_change(
+    temp_workspace, mock_config_two_groups
+):
+    """Only the conversion group whose config actually changed is reconverted;
+    a sibling group with an unchanged config block stays skipped."""
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(
+                mock_config_two_groups["conversion_defaults"]
+            ),
+            "conversions": [
+                {
+                    "name": "group_a",
+                    "input": ["rules/*.yml"],
+                    "target": "loki",
+                    "format": "default",
+                },
+                {
+                    "name": "group_b",
+                    "input": ["rules/*.yml"],
+                    "target": "elastic",
+                    "format": "default",
+                },
+            ],
+        }
+    )
+    mock_config_two_groups._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config_two_groups,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    conversion_dir = temp_workspace / "conversions"
+    assert (conversion_dir / "group_b_test.json").exists()
+    assert not (conversion_dir / "group_a_test.json").exists()
+
+
+def test_convert_rules_identical_previous_config_skips(temp_workspace, mock_config):
+    """An identical previous_config is not itself a reason to reconvert; the
+    usual changed-files skip logic still applies."""
+    convert_rules(
+        config=mock_config,
+        previous_config=mock_config,
+        path_prefix=temp_workspace,
+        changed_files="rules/different.yml",
+    )
+
+    output_file = temp_workspace / "conversions" / "test_conversion_test.json"
+    assert not output_file.exists()
+
+
+def test_convert_rules_config_key_order_does_not_reconvert(temp_workspace, mock_config):
+    """A conversion block that is semantically identical, just with its keys
+    in a different order, must not be treated as changed."""
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(mock_config["conversion_defaults"]),
+            "conversions": [
+                {
+                    "format": "default",
+                    "target": "loki",
+                    "input": ["rules/*.yml"],
+                    "name": "test_conversion",
+                }
+            ],
+        }
+    )
+
+    convert_rules(
+        config=mock_config,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="rules/different.yml",
+    )
+
+    output_file = temp_workspace / "conversions" / "test_conversion_test.json"
+    assert not output_file.exists()
+
+
+def test_convert_rules_without_previous_config_behaves_as_before(
+    temp_workspace, mock_config
+):
+    """previous_config is optional; omitting it must not change existing
+    behavior for a normal changed-files run."""
+    convert_rules(
+        config=mock_config,
+        path_prefix=temp_workspace,
+        changed_files="rules/test.yml",
+    )
+
+    output_file = temp_workspace / "conversions" / "test_conversion_test.json"
+    assert output_file.exists()
+
+
+def test_convert_rules_config_change_respects_manual_flag(temp_workspace, mock_config):
+    """A group-wide reconvert triggered by a config change must still skip
+    an output file already marked manual."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    output_file = conversion_dir / "test_conversion_test.json"
+    manual_content = json.dumps({"manual": True, "queries": ["HAND EDITED"]}).decode(
+        "utf-8"
+    )
+    output_file.write_text(manual_content)
+
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(mock_config["conversion_defaults"]),
+            "conversions": [
+                {
+                    "name": "test_conversion",
+                    "input": ["rules/*.yml"],
+                    "target": "splunk",
+                    "format": "default",
+                }
+            ],
+        }
+    )
+    mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    assert output_file.read_text() == manual_content
+
+
+def test_convert_rules_multiple_new_groups_convert_independently(
+    temp_workspace, mock_config_two_groups
+):
+    """Several conversion groups added in the same config update all convert,
+    independently of one another."""
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(
+                mock_config_two_groups["conversion_defaults"]
+            ),
+            "conversions": [],
+        }
+    )
+    mock_config_two_groups._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config_two_groups,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    conversion_dir = temp_workspace / "conversions"
+    assert (conversion_dir / "group_a_test.json").exists()
+    assert (conversion_dir / "group_b_test.json").exists()
+
+
+def test_convert_rules_default_change_reconverts_all_groups(temp_workspace):
+    """A change to a top-level conversion_defaults value affects every group
+    that inherits it, so the whole repository is reconverted, not just the
+    group whose own block happened to change."""
+    shared_conversions = [
+        {"name": "group_a", "input": ["rules/*.yml"]},
+        {"name": "group_b", "input": ["rules/*.yml"]},
+    ]
+    config = DynaconfDict(
+        {
+            "conversion_defaults": {
+                "target": "splunk",
+                "format": "default",
+                "skip_unsupported": "true",
+                "file_pattern": "*.yml",
+            },
+            "conversions": shared_conversions,
+        }
+    )
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": {
+                "target": "loki",
+                "format": "default",
+                "skip_unsupported": "true",
+                "file_pattern": "*.yml",
+            },
+            "conversions": shared_conversions,
+        }
+    )
+    config._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=config,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    conversion_dir = temp_workspace / "conversions"
+    assert (conversion_dir / "group_a_test.json").exists()
+    assert (conversion_dir / "group_b_test.json").exists()
+
+
+def test_convert_rules_dropped_input_entry_deletes_stale_output(
+    temp_workspace, mock_config
+):
+    """A rule dropped from a conversion's input list, with the
+    file left in place on disk, has its stale conversion output deleted even
+    though the rule was never in changed_files or deleted_files."""
+    (temp_workspace / "rules" / "keep.yml").write_text(
+        (temp_workspace / "rules" / "test.yml").read_text()
+    )
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    stale_output = conversion_dir / "test_conversion_test.json"
+    stale_output.write_text(
+        json.dumps(
+            {"conversion_name": "test_conversion", "input_file": "rules/test.yml"}
+        ).decode("utf-8")
+    )
+
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(mock_config["conversion_defaults"]),
+            "conversions": [
+                {
+                    "name": "test_conversion",
+                    "input": ["rules/test.yml", "rules/keep.yml"],
+                    "target": "loki",
+                    "format": "default",
+                }
+            ],
+        }
+    )
+    mock_config["conversions"][0]["input"] = ["rules/keep.yml"]
+    mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    assert not stale_output.exists()
+    # The entry that's still in scope must still be (re)converted.
+    assert (conversion_dir / "test_conversion_keep.json").exists()
+
+
+def test_convert_rules_narrowed_input_pattern_keeps_still_matched_files(
+    temp_workspace, mock_config
+):
+    """Narrowing a glob (rather than dropping a specific file) must not
+    delete output for a rule that's still matched by the narrower pattern,
+    even though the old, broader pattern string is no longer present."""
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    still_valid_output = conversion_dir / "test_conversion_test.json"
+    still_valid_output.write_text(
+        json.dumps(
+            {"conversion_name": "test_conversion", "input_file": "rules/test.yml"}
+        ).decode("utf-8")
+    )
+
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(mock_config["conversion_defaults"]),
+            "conversions": [
+                {
+                    "name": "test_conversion",
+                    "input": ["rules/*.yml"],
+                    "target": "loki",
+                    "format": "default",
+                }
+            ],
+        }
+    )
+    mock_config["conversions"][0]["input"] = ["rules/test.yml"]
+    mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    assert still_valid_output.exists()
+
+
+def test_convert_rules_reassigned_input_moves_output_between_groups(
+    temp_workspace, mock_config_two_groups
+):
+    """A rule reassigned from one conversion's input to another's
+    via a config edit (not a git-detected file change) gets its old group's
+    stale output deleted while the new group produces fresh output."""
+    (temp_workspace / "rules" / "keep.yml").write_text(
+        (temp_workspace / "rules" / "test.yml").read_text()
+    )
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    stale_output = conversion_dir / "group_a_test.json"
+    stale_output.write_text(
+        json.dumps(
+            {"conversion_name": "group_a", "input_file": "rules/test.yml"}
+        ).decode("utf-8")
+    )
+
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(
+                mock_config_two_groups["conversion_defaults"]
+            ),
+            "conversions": [
+                {
+                    "name": "group_a",
+                    "input": ["rules/test.yml", "rules/keep.yml"],
+                    "target": "loki",
+                    "format": "default",
+                },
+                {
+                    "name": "group_b",
+                    "input": [],
+                    "target": "text_query_test",
+                    "format": "default",
+                },
+            ],
+        }
+    )
+    mock_config_two_groups["conversions"][0]["input"] = ["rules/keep.yml"]
+    mock_config_two_groups["conversions"][1]["input"] = ["rules/test.yml"]
+    mock_config_two_groups._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config_two_groups,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    # The old owner's stale output for the reassigned rule is gone.
+    assert not stale_output.exists()
+    # The new owner produced fresh output for it.
+    assert (conversion_dir / "group_b_test.json").exists()
+    # The old owner's remaining rule is unaffected.
+    assert (conversion_dir / "group_a_keep.json").exists()
+
+
+def test_convert_rules_dropped_input_entry_respects_manual_flag(
+    temp_workspace, mock_config
+):
+    """A manually-maintained conversion file must not be deleted just because
+    its rule was dropped from the conversion's input list."""
+    (temp_workspace / "rules" / "keep.yml").write_text(
+        (temp_workspace / "rules" / "test.yml").read_text()
+    )
+    conversion_dir = temp_workspace / "conversions"
+    conversion_dir.mkdir()
+    manual_output = conversion_dir / "test_conversion_test.json"
+    manual_content = json.dumps(
+        {
+            "conversion_name": "test_conversion",
+            "input_file": "rules/test.yml",
+            "manual": True,
+            "queries": ["HAND EDITED"],
+        }
+    ).decode("utf-8")
+    manual_output.write_text(manual_content)
+
+    previous_config = DynaconfDict(
+        {
+            "conversion_defaults": dict(mock_config["conversion_defaults"]),
+            "conversions": [
+                {
+                    "name": "test_conversion",
+                    "input": ["rules/test.yml", "rules/keep.yml"],
+                    "target": "loki",
+                    "format": "default",
+                }
+            ],
+        }
+    )
+    mock_config["conversions"][0]["input"] = ["rules/keep.yml"]
+    mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
+
+    convert_rules(
+        config=mock_config,
+        previous_config=previous_config,
+        path_prefix=temp_workspace,
+        changed_files="config.yaml",
+    )
+
+    assert manual_output.read_text() == manual_content

--- a/actions/convert/test_convert.py
+++ b/actions/convert/test_convert.py
@@ -1559,11 +1559,13 @@ def test_convert_rules_unrelated_group_not_reconverted_on_config_change(
 def test_convert_rules_identical_previous_config_skips(temp_workspace, mock_config):
     """An identical previous_config is not itself a reason to reconvert; the
     usual changed-files skip logic still applies."""
+    mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
+
     convert_rules(
         config=mock_config,
         previous_config=mock_config,
         path_prefix=temp_workspace,
-        changed_files="rules/different.yml",
+        changed_files="config.yaml",
     )
 
     output_file = temp_workspace / "conversions" / "test_conversion_test.json"
@@ -1586,12 +1588,13 @@ def test_convert_rules_config_key_order_does_not_reconvert(temp_workspace, mock_
             ],
         }
     )
+    mock_config._loaded_files = [str(temp_workspace / "config.yaml")]
 
     convert_rules(
         config=mock_config,
         previous_config=previous_config,
         path_prefix=temp_workspace,
-        changed_files="rules/different.yml",
+        changed_files="config.yaml",
     )
 
     output_file = temp_workspace / "conversions" / "test_conversion_test.json"
@@ -1603,6 +1606,7 @@ def test_convert_rules_without_previous_config_behaves_as_before(
 ):
     """previous_config is optional; omitting it must not change existing
     behavior for a normal changed-files run."""
+
     convert_rules(
         config=mock_config,
         path_prefix=temp_workspace,


### PR DESCRIPTION
closes #271
closes #242 
closes #180 
closes #168 

This PR closes all these issues by adressing the core underlying issue: changes in the `config.yml` not being tracked up until now.

#271 and #242 are primarily solved by comparing the old version of the config (fetched from the determined `PREVIOUS_REF`) against the current and listing conversion groups that had changes and fully converting all of their rules.

For #180 and #168 in addition it checks the input of the previous config and current config and checks for any converted rules that were dropped and lists them for deletion.

### Manual Integration testing

- https://github.com/grafana/sigma-internal/pull/322 showcases conversion triggered by a config change
- https://github.com/grafana/sigma-internal/pull/324 showcases more:
  - an existing rule being added to a new config and being picked up and converted (#271)
  - a conversion group being renamed properly creating new and deleting old conversions (#242)
  - removes a single rule from a conversion group and conversion gets properly deleted (#168)