### PR TITLE
Ensure identify-commits logs errors if it receives no commits

### DIFF
--- a/scripts/identify-commits/identify-commits.js
+++ b/scripts/identify-commits/identify-commits.js
@@ -86,8 +86,16 @@ async function identifyCommits(octokit, context, prNumber, actionsUsername) {
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: prNumber,
-    per_page: 1
+    per_page: 100
   }));
+
+  if (iterator.length === 0) {
+    throw new Error(
+      `No commits were returned for pull request #${prNumber}. This can happen if the GitHub API ` +
+      'has not yet finished indexing the pull request (e.g. immediately after it was opened or ' +
+      'synchronized), or if the request otherwise failed transiently. Retrying the job usually resolves it.'
+    );
+  }
 
   let previousCommit = "";
   let firstCommit = "";

--- a/scripts/identify-commits/test/identifyCommits.test.js
+++ b/scripts/identify-commits/test/identifyCommits.test.js
@@ -281,3 +281,29 @@ test('identifyCommits - custom actions username', async () => {
   assert.strictEqual(results.previousRef, 'commit2');
 });
 
+test('identifyCommits - throws when the API returns no commits', async () => {
+  const mockOctokit = {
+    paginate: async (endpoint) => {
+      return [];
+    },
+    rest: {
+      pulls: {
+        listCommits: {
+          endpoint: {
+            merge: (params) => params
+          }
+        }
+      }
+    }
+  };
+
+  const context = {
+    repo: { owner: 'test-owner', repo: 'test-repo' }
+  };
+
+  await assert.rejects(
+    () => identifyModule.identifyCommits(mockOctokit, context, 123, 'github-actions[bot]'),
+    /No commits were returned for pull request #123/
+  );
+});
+


### PR DESCRIPTION
I've seen a couple of instances where SRD will fail to convert files as it is unable to identify **any** relevant base or last commits/refs. It will output:
```
Base commit or base ref:
Last commit or base ref:
PR First Commit:
PR Last Commit by automation:
PR Previous Ref:
Commit identification completed successfully
```

Clearly this was not successful - but it seems to be unable to identify that :laughing: With a bit of Claude investigation support, it seems that if the GH API returns a 409 response (more common than it used to be :cry: ), the Octokit lib will treat it as an empty list of commits, and with an iterator length of 1, we were making a lot of requests, making this more likely to happen.

This PR increases the size of the iterator and checks for an empty response, correctly generating an error rather than silently continuing to a "bad ref" error later down the line.