### PR TITLE
Store integration query test results in file

### DIFF
--- a/.github/workflows/convert-integrate.yml
+++ b/.github/workflows/convert-integrate.yml
@@ -23,7 +23,7 @@ on:
         type: boolean
         default: false
       output_log_lines:
-        description: "Output log lines to the outputs of the test_query_results"
+        description: "Output log lines to the outputs of the test_query_results_file"
         required: false
         type: boolean
         default: false

--- a/actions/integrate/README.md
+++ b/actions/integrate/README.md
@@ -13,7 +13,7 @@ The Grafana Query Integrator action bridges the gap between converted Sigma rule
 | `config_path`                      | Path to the configuration file for the Sigma Rule Integrator                                         | Yes      | `""`                  |
 | `grafana_sa_token`                 | Service account token for Grafana for query testing                                                  | No       | `""`                  |
 | `pretty_print`                     | Pretty print the JSON output                                                                         | No       | `false`               |
-| `output_log_lines`                 | Output log lines to the outputs of the test_query_results                                            | No       | `false`               |
+| `output_log_lines`                 | Output log lines to the outputs of the test_query_results_file                                       | No       | `false`               |
 | `all_rules`                        | Whether to integrate all rules                                                                       | No       | `false`               |
 | `changed_files_from_base`          | Whether to use the changed files from the base branch                                                | No       | `false`               |
 | `actions_username`                 | The username of the actions user                                                                     | No       | `github-actions[bot]` |
@@ -21,10 +21,10 @@ The Grafana Query Integrator action bridges the gap between converted Sigma rule
 
 ## Outputs
 
-| Name                 | Description                                                                                                |
-| -------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `rules_integrated`   | List of the filenames of alert rule files created, updated or deleted during integration (space-separated) |
-| `test_query_results` | The results of testing the queries against the datasource for the past hour                                |
+| Name                      | Description                                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `rules_integrated`        | List of the filenames of alert rule files created, updated or deleted during integration (space-separated)         |
+| `test_query_results_file` | Path (relative to the job workspace) to a JSON file with the results of testing the queries against the datasource for the past hour. Only set when query testing ran. |
 
 ## Usage
 
@@ -102,7 +102,7 @@ jobs:
 - Query testing is optional but recommended for validation.
 - Requires a valid Grafana Service Account token with appropriate permissions.
 - Tests queries against the past hour of data to validate syntax and execution.
-- Results are included in the `test_query_results` output.
+- Results are written to a JSON file whose path is exposed via the `test_query_results_file` output, rather than being included in the output value directly — this keeps large rulesets from overflowing environment-variable size limits in later workflow steps.
 
 ### File Management
 

--- a/actions/integrate/action.yml
+++ b/actions/integrate/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: "false"
   output_log_lines:
-    description: "Output log lines to the outputs of the test_query_results"
+    description: "Output log lines to the outputs of the test_query_results_file"
     required: false
     default: "false"
   all_rules:
@@ -40,9 +40,9 @@ outputs:
   rules_integrated:
     description: "The repository file names changed (added/updated or removed) by this Action"
     value: ${{ steps.set-output.outputs.rules_integrated }}
-  test_query_results:
-    description: "The results of testing the queries against the datasource for the past hour"
-    value: ${{ steps.set-output.outputs.test_query_results }}
+  test_query_results_file:
+    description: "Path (relative to the job workspace) to a JSON file with the results of testing the queries against the datasource for the past hour. Only set when query testing ran (grafana_sa_token provided)."
+    value: ${{ steps.set-output.outputs.test_query_results_file }}
 
 runs:
   using: "composite"
@@ -139,6 +139,7 @@ runs:
             -e MANUAL_FILES="$MANUAL_FILES" \
             -e ALL_RULES="$ALL_RULES" \
             -e CONTINUE_ON_QUERY_TESTING_ERRORS="$CONTINUE_ON_QUERY_TESTING_ERRORS" \
+            -e TEST_QUERY_RESULTS_FILE=test-query-results.json \
             "ghcr.io/grafana/sigma-rule-deployment/sigma-rule-deployer:$IMAGE_REF" \
             integrate
     - name: Set output
@@ -154,7 +155,7 @@ runs:
         PULL_REQUEST_NUMBER: ${{ github.event.number || github.event.issue.number }}
         BASE_REF: ${{ steps.commits.outputs.base-commit }}
         DEPLOYMENT_PATH: ${{ steps.config-paths.outputs.deployment_path }}
-        TEST_RESULTS: ${{ steps.set-output.outputs.test_query_results }}
+        TEST_RESULTS_FILE: ${{ steps.set-output.outputs.test_query_results_file }}
         COMMENT_TITLE: 'Sigma Rule Integrations'
         COMMENT_IDENTIFIER: 'Sigma Rule Integrations'
         GITHUB_TOKEN: ${{ github.token }}
@@ -183,3 +184,12 @@ runs:
         fi
 
         node comment.js
+
+    - name: Cleanup test results file
+      id: cleanup-test-results
+      if: ${{ always() && steps.set-output.outputs.test_query_results_file != '' }}
+      shell: bash
+      env:
+        TEST_RESULTS_FILE: ${{ steps.set-output.outputs.test_query_results_file }}
+      run: |
+        rm -f -- "$TEST_RESULTS_FILE"

--- a/internal/querytest/querytest.go
+++ b/internal/querytest/querytest.go
@@ -138,9 +138,13 @@ func (qt *QueryTester) Run() error {
 		return fmt.Errorf("error marshalling query results: %v", err)
 	}
 
-	// Set a single output with all results
-	if err := shared.SetOutput("test_query_results", string(resultsJSON)); err != nil {
-		return fmt.Errorf("failed to set test query results output: %w", err)
+	// Write to a file rather than $GITHUB_OUTPUT directly, since this blob can grow large enough to hit E2BIG.
+	resultsPath := os.Getenv("TEST_QUERY_RESULTS_FILE")
+	if resultsPath == "" {
+		resultsPath = "test-query-results.json"
+	}
+	if err := shared.SetFileOutput("test_query_results_file", resultsPath, string(resultsJSON)); err != nil {
+		return fmt.Errorf("failed to write test query results file: %w", err)
 	}
 
 	return nil

--- a/internal/querytest/querytest_test.go
+++ b/internal/querytest/querytest_test.go
@@ -157,6 +157,10 @@ func TestRun(t *testing.T) {
 			os.Setenv("GITHUB_OUTPUT", outputFile.Name())
 			defer os.Unsetenv("GITHUB_OUTPUT")
 
+			resultsFile := filepath.Join(testDir, "test-query-results.json")
+			os.Setenv("TEST_QUERY_RESULTS_FILE", resultsFile)
+			defer os.Unsetenv("TEST_QUERY_RESULTS_FILE")
+
 			// Create mock query executor
 			var mockDatasourceQuery integrate.DatasourceQuery
 			if tt.mockQueryError {
@@ -189,14 +193,20 @@ func TestRun(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			// Verify test_query_results output was set if testing was performed
+			// Verify test_query_results_file output was set if testing was performed
 			if tt.expectTestResults && len(tt.convOutput.Queries) > 0 {
 				_, err = outputFile.Seek(0, 0)
 				assert.NoError(t, err)
 				outputBytes, err := io.ReadAll(outputFile)
 				assert.NoError(t, err)
 				outputContent := string(outputBytes)
-				assert.Contains(t, outputContent, "test_query_results=")
+				assert.Contains(t, outputContent, "test_query_results_file="+resultsFile)
+
+				resultsBytes, err := os.ReadFile(resultsFile)
+				assert.NoError(t, err)
+				var results map[string][]model.QueryTestResult
+				assert.NoError(t, json.Unmarshal(resultsBytes, &results))
+				assert.NotEmpty(t, results)
 			}
 		})
 	}

--- a/scripts/comment-sigma-results/README.md
+++ b/scripts/comment-sigma-results/README.md
@@ -7,7 +7,7 @@ Posts formatted comments to pull requests showing Sigma rule conversion/integrat
 - Extracts `title` field from JSON files (supports top-level or nested in `rules` array)
 - Creates clickable links to changed files in the PR
 - Minimizes outdated comments from previous runs
-- Automatically generates test results table from `TEST_RESULTS` JSON (when provided)
+- Automatically generates test results table from the JSON file referenced by `TEST_RESULTS_FILE` (when provided)
 
 ## Usage
 
@@ -47,7 +47,7 @@ node comment.js
 | `DELETED_FILES` | Space-separated list of deleted file paths | Yes |
 | `COMMENT_TITLE` | Title for the comment section | Yes |
 | `COMMENT_IDENTIFIER` | String to identify old comments for cleanup (will be hidden in comment) | Yes |
-| `TEST_RESULTS` | JSON string of test results (object mapping file paths to arrays of QueryTestResult) | No |
+| `TEST_RESULTS_FILE` | Path (workspace-relative or absolute) to a JSON file of test results (object mapping file paths to arrays of QueryTestResult) | No |
 | `GITHUB_TOKEN` | GitHub token for API access | Yes |
 | `GITHUB_REPOSITORY` | Repository in format `owner/repo` | Yes (for local) |
 
@@ -76,7 +76,7 @@ node comment.js
 | Rule Title | [See in Explore](link) | 42 | 0 |
 ```
 
-The test results table is automatically included when `TEST_RESULTS` is provided.
+The test results table is automatically included when `TEST_RESULTS_FILE` is provided.
 
 ## Dependencies
 

--- a/scripts/comment-sigma-results/comment.js
+++ b/scripts/comment-sigma-results/comment.js
@@ -11,11 +11,11 @@
  *
  * Environment variables (for GitHub Actions):
  *   PULL_REQUEST_NUMBER, CHANGED_FILES, DELETED_FILES, COMMENT_TITLE,
- *   COMMENT_IDENTIFIER, TEST_RESULTS, GITHUB_TOKEN
+ *   COMMENT_IDENTIFIER, TEST_RESULTS_FILE, GITHUB_TOKEN
  *
  * CLI arguments (for local testing):
  *   --pr-number, --changed-files, --deleted-files, --title, --identifier,
- *   --test-results, --token
+ *   --test-results-file, --token
  */
 
 import * as core from '@actions/core';

--- a/scripts/comment-sigma-results/lib/comment-body.js
+++ b/scripts/comment-sigma-results/lib/comment-body.js
@@ -102,7 +102,7 @@ export function splitCommentIntoChunks(comment, commentIdentifier, maxCommentSiz
 
 /**
  * Render the full comment body: the changed/deleted file lists, the test
- * results table (when TEST_RESULTS was provided) and the conversion errors
+ * results table (when TEST_RESULTS_FILE was provided) and the conversion errors
  * table (when CONVERSION_ERRORS was provided).
  */
 export function buildCommentBody({
@@ -117,7 +117,7 @@ export function buildCommentBody({
   // Build file list with titles
   const changedFilesList = buildChangedFilesList(changedFiles, repoUrl, headRef);
 
-  // Build test results table if TEST_RESULTS is provided
+  // Build test results table if TEST_RESULTS_FILE was provided and parsed successfully
   const testResultsTable = testResults ? buildTestResultsTable(testResults) : '';
 
   // Build errors table if CONVERSION_ERRORS is provided

--- a/scripts/comment-sigma-results/lib/inputs.js
+++ b/scripts/comment-sigma-results/lib/inputs.js
@@ -1,5 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
 import * as core from '@actions/core';
 import * as github from '@actions/github';
+
+/**
+ * Read and parse the JSON file referenced by TEST_RESULTS_FILE.
+ */
+function readTestResultsFile(filePath) {
+  if (!filePath) return null;
+  const resolved = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(process.env.RULE_DIRECTORY_PATH || process.cwd(), filePath);
+  try {
+    return JSON.parse(fs.readFileSync(resolved, 'utf8'));
+  } catch (e) {
+    console.log(`Failed to read/parse test results file (${resolved}):`, e.message);
+    return null;
+  }
+}
 
 /**
  * Get inputs from environment variables or CLI arguments
@@ -10,15 +29,8 @@ export function getInputs() {
 
   if (isGitHubActions) {
     // Use @actions/core for GitHub Actions
-    let testResults = null;
-    const testResultsStr = core.getInput('test_results') || process.env.TEST_RESULTS;
-    if (testResultsStr) {
-      try {
-        testResults = JSON.parse(testResultsStr);
-      } catch (e) {
-        console.log('Failed to parse TEST_RESULTS JSON:', e.message);
-      }
-    }
+    const testResultsFile = core.getInput('test_results_file') || process.env.TEST_RESULTS_FILE;
+    const testResults = readTestResultsFile(testResultsFile);
 
     let errorResults = null;
     const errorResultsStr = core.getInput('conversion_errors') || process.env.CONVERSION_ERRORS;
@@ -53,15 +65,8 @@ export function getInputs() {
       }
     }
 
-    let testResults = null;
-    const testResultsStr = inputs.test_results || process.env.TEST_RESULTS;
-    if (testResultsStr) {
-      try {
-        testResults = JSON.parse(testResultsStr);
-      } catch (e) {
-        console.log('Failed to parse TEST_RESULTS JSON:', e.message);
-      }
-    }
+    const testResultsFile = inputs.test_results_file || process.env.TEST_RESULTS_FILE;
+    const testResults = readTestResultsFile(testResultsFile);
 
     let errorResults = null;
     const errorResultsStr = inputs.conversion_errors || process.env.CONVERSION_ERRORS;

--- a/scripts/comment-sigma-results/lib/tables.js
+++ b/scripts/comment-sigma-results/lib/tables.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { extractTitle } from './extract-title.js';
 
 /**
- * Build test results table from TEST_RESULTS JSON
+ * Build test results table from the parsed TEST_RESULTS_FILE contents
  */
 export function buildTestResultsTable(testResults) {
   if (!testResults || Object.keys(testResults).length === 0) {

--- a/scripts/comment-sigma-results/test/getInputs.test.js
+++ b/scripts/comment-sigma-results/test/getInputs.test.js
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import { getInputs } from '../lib/inputs.js';
+
+function withEnv(overrides, fn) {
+  const original = {};
+  for (const key of Object.keys(overrides)) {
+    original[key] = process.env[key];
+    if (overrides[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = overrides[key];
+    }
+  }
+  try {
+    fn();
+  } finally {
+    for (const key of Object.keys(original)) {
+      if (original[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original[key];
+      }
+    }
+  }
+}
+
+test('getInputs - GitHub Actions branch reads and parses TEST_RESULTS_FILE', (t) => {
+  const results = { 'rules/a.json': [{ datasource: 'loki', link: '', stats: { count: 1 } }] };
+
+  withEnv({ GITHUB_ACTIONS: 'true', TEST_RESULTS_FILE: 'test-query-results.json' }, () => {
+    t.mock.method(fs, 'readFileSync', () => JSON.stringify(results));
+    const inputs = getInputs();
+    assert.deepStrictEqual(inputs.testResults, results);
+  });
+});
+
+test('getInputs - GitHub Actions branch returns null when TEST_RESULTS_FILE unset', (t) => {
+  withEnv({ GITHUB_ACTIONS: 'true', TEST_RESULTS_FILE: undefined }, () => {
+    const inputs = getInputs();
+    assert.strictEqual(inputs.testResults, null);
+  });
+});
+
+test('getInputs - GitHub Actions branch returns null when the file is missing', (t) => {
+  withEnv({ GITHUB_ACTIONS: 'true', TEST_RESULTS_FILE: 'does-not-exist.json' }, () => {
+    t.mock.method(fs, 'readFileSync', () => {
+      throw new Error('ENOENT: no such file or directory');
+    });
+    const inputs = getInputs();
+    assert.strictEqual(inputs.testResults, null);
+  });
+});
+
+test('getInputs - GitHub Actions branch returns null on malformed JSON', (t) => {
+  withEnv({ GITHUB_ACTIONS: 'true', TEST_RESULTS_FILE: 'test-query-results.json' }, () => {
+    t.mock.method(fs, 'readFileSync', () => '{not valid json');
+    const inputs = getInputs();
+    assert.strictEqual(inputs.testResults, null);
+  });
+});
+
+test('getInputs - CLI fallback branch reads and parses TEST_RESULTS_FILE', (t) => {
+  const results = { 'rules/b.json': [{ datasource: 'elasticsearch', link: '', stats: { count: 2 } }] };
+
+  withEnv({ GITHUB_ACTIONS: undefined, TEST_RESULTS_FILE: 'test-query-results.json' }, () => {
+    t.mock.method(fs, 'readFileSync', () => JSON.stringify(results));
+    const inputs = getInputs();
+    assert.deepStrictEqual(inputs.testResults, results);
+  });
+});

--- a/shared/util.go
+++ b/shared/util.go
@@ -26,14 +26,21 @@ func GetInputOrDefault(name string, value string) string {
 	return env
 }
 
+func validateOutputFilePath(path string) error {
+	cleaned := filepath.Clean(path)
+	if cleaned != path || strings.HasPrefix(cleaned, "..") {
+		return errors.New("output file path is invalid")
+	}
+	return nil
+}
+
 func SetOutput(output, value string) error {
 	outputFile := os.Getenv("GITHUB_OUTPUT")
 	if outputFile == "" {
 		return errors.New("only output with a github output file supported. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for further details")
 	}
-	cleaned := filepath.Clean(outputFile)
-	if cleaned != outputFile || strings.HasPrefix(cleaned, "..") {
-		return errors.New("GITHUB_OUTPUT path is invalid")
+	if err := validateOutputFilePath(outputFile); err != nil {
+		return fmt.Errorf("GITHUB_OUTPUT path is invalid: %w", err)
 	}
 
 	f, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gosec // G703: outputFile validated to reject path traversal above
@@ -48,6 +55,18 @@ func SetOutput(output, value string) error {
 	}
 
 	return nil
+}
+
+// SetFileOutput writes content to path and records path (not content) as the named
+// GitHub Actions output, avoiding E2BIG failures when a later step reads it into an env var.
+func SetFileOutput(output, path, content string) error {
+	if err := validateOutputFilePath(path); err != nil {
+		return fmt.Errorf("%s output file path is invalid: %w", output, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil { //nolint:gosec // G703: path validated to reject path traversal above
+		return fmt.Errorf("unable to write %s output file: %w", output, err)
+	}
+	return SetOutput(output, path)
 }
 
 func ReadLocalFile(path string) (string, error) {


### PR DESCRIPTION
Storing the raw JSON in a variable was quickly hitting system limits (E2BIG) when query testing a large number of queries. This places the output in a single file and passes the file path to the next stage instead.

**Note:** this is a BREAKING CHANGE to the integrator action, and will require a minor version increment.