### PR TITLE
Move concurrency control to integration test and queue

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,9 @@
+paths:
+  '**/*':
+    ignore:
+      # actionlint's schema predates the `queue` key GitHub added to the `concurrency` section, so it
+      # rejects a valid workflow. Temporary until actionlint learns the key. Upstream:
+      #    - issue: https://github.com/rhysd/actionlint/issues/657
+      # Note that this is NOT fixed as of actionlint 1.7.12, so upgrading alone will not remove the need
+      # for this. Drop it once a release actually recognises the key, and re-run the check to confirm.
+      - 'unexpected key "queue" for "concurrency" section.*'

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,12 +11,6 @@ on:
     types:
       - published
 
-# Prevent concurrent execution of these workflows to avoid multiple executions commiting to main simultaneously
-# We **need** to commit to main to test the commenting feature
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
-
 permissions: {}
 
 jobs:
@@ -127,6 +121,14 @@ jobs:
           push: true
 
   test-pr:
+    # Prevent concurrent execution of integration tests to avoid multiple executions commiting to main simultaneously
+    # We **need** to commit to main to test the commenting feature
+    # Use concurrency queuing rather than just killing the existing jobs
+    concurrency:
+      group: ${{ github.workflow }}
+      queue: max
+
+
     # Only same-repo PRs run the integration test automatically here (they have
     # secrets + a package-write token). Fork PRs export an image artifact in the
     # build job above; a maintainer runs the integration test manually from the


### PR DESCRIPTION
Previously, we prevented all concurrent runs of the build and test workflow. However, we only require limiting concurrency on the integration test, and rather than killing previous runs, we can instead [queue them](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-queueing-multiple-pending-runs) and wait for the others to finish.