### PR TITLE
Set the Docker user correctly for actions

### DIFF
--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -133,6 +133,7 @@ runs:
         IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
       run: |
         docker run --rm \
+            --user "$(id -u):$(id -g)" \
             -v "$(pwd):/sigma-rules" \
             -w /sigma-rules \
             -e GITHUB_WORKSPACE=/sigma-rules \

--- a/actions/convert/action.yml
+++ b/actions/convert/action.yml
@@ -133,7 +133,6 @@ runs:
         IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
       run: |
         docker run --rm \
-            --user "$(id -u):$(id -g)" \
             -v "$(pwd):/sigma-rules" \
             -w /sigma-rules \
             -e GITHUB_WORKSPACE=/sigma-rules \

--- a/actions/deploy/action.yml
+++ b/actions/deploy/action.yml
@@ -76,6 +76,7 @@ runs:
       run: |
         rm -f .sigma-deploy-output
         docker run --rm \
+            --user "$(id -u):$(id -g)" \
             -v "$(pwd):/sigma-rules" \
             -w /sigma-rules \
             -e GITHUB_OUTPUT="/sigma-rules/.sigma-deploy-output" \

--- a/actions/integrate/action.yml
+++ b/actions/integrate/action.yml
@@ -127,6 +127,7 @@ runs:
         IMAGE_REF: ${{ steps.image-ref.outputs.image_ref }}
       run: |
         docker run --rm \
+            --user "$(id -u):$(id -g)" \
             -v "$(pwd):/sigma-rules" \
             -w /sigma-rules \
             -e GITHUB_OUTPUT=/sigma-rules/github-output \


### PR DESCRIPTION
The integrator is producing output files owned by the `root` user. This changes the docker run command to use the runner user, avoiding this issue.