### PR TITLE
Fix incorrect detection of table separators

### DIFF
--- a/scripts/comment-sigma-results/lib/comment-body.js
+++ b/scripts/comment-sigma-results/lib/comment-body.js
@@ -32,8 +32,9 @@ export function splitCommentIntoChunks(comment, commentIdentifier, maxCommentSiz
   for (const line of comment.split('\n')) {
     const lineWithNewline = line + '\n';
 
+    const TABLE_SEPARATOR_REGEX = /^\|(?:\s*:?-+:?\s*\|)+$/;
     // If the line is a table header, store it
-    if (line.startsWith('|') && line.includes('---')) {
+    if (line.startsWith('|') && TABLE_SEPARATOR_REGEX.test(line.trim())) {
       lastTableHeader = currentChunk.split('\n').slice(0,-1).pop() + '\n' + lineWithNewline;
     } else if (!line.startsWith('|') && lastTableHeader) {
       lastTableHeader = ''; // Reset if we are no longer in a table
@@ -57,7 +58,7 @@ export function splitCommentIntoChunks(comment, commentIdentifier, maxCommentSiz
         } else if (line.startsWith('### ')) {
           preparedNewChunk = line + '\n' + preparedNewChunk;
           chunkLines.splice(i, 1);
-        } else if( line.startsWith('|') && line.includes('---')) {
+        } else if (line.startsWith('|') && TABLE_SEPARATOR_REGEX.test(line.trim())) {
           preparedNewChunk = chunkLines.splice(i-1, 2).join('\n') + '\n' + preparedNewChunk;
           i--; // Skip the next line since we already spliced it
         }

--- a/scripts/comment-sigma-results/lib/comment-body.js
+++ b/scripts/comment-sigma-results/lib/comment-body.js
@@ -32,7 +32,7 @@ export function splitCommentIntoChunks(comment, commentIdentifier, maxCommentSiz
   for (const line of comment.split('\n')) {
     const lineWithNewline = line + '\n';
 
-    const TABLE_SEPARATOR_REGEX = /^\|(?:\s*:?-+:?\s*\|)+$/;
+    const TABLE_SEPARATOR_REGEX = /^\|(?:\s*:?-{3,}:?\s*\|)+$/;
     // If the line is a table header, store it
     if (line.startsWith('|') && TABLE_SEPARATOR_REGEX.test(line.trim())) {
       lastTableHeader = currentChunk.split('\n').slice(0,-1).pop() + '\n' + lineWithNewline;

--- a/scripts/comment-sigma-results/test/splitCommentIntoChunks.test.js
+++ b/scripts/comment-sigma-results/test/splitCommentIntoChunks.test.js
@@ -22,6 +22,14 @@ const SAFETY_MARGIN = commentByteSize(`${partLabel(100, 100)}\n\n${IDENTIFIER_MA
 
 /** A comment shaped like the ones buildCommentBody renders, built here to keep the test isolated. */
 function buildComment() {
+  return buildCommentWithInjectedLine();
+}
+
+function buildCommentWithInjectedLine(
+  injectedTableLine = "", 
+  injectedTableLineIndex = -1, 
+  injectedChangedFilesLine = "", 
+  injectedChangedFilesLineIndex = -1) {
   return [
     '',
     TITLE,
@@ -32,7 +40,7 @@ function buildComment() {
     '',
     CHANGED_HEADING,
     '',
-    ...Array.from({ length: 20 }, (_, i) => changedFile(i)),
+    ...Array.from({ length: 20 }, (_, i) => i == injectedChangedFilesLineIndex ? injectedChangedFilesLine : changedFile(i)),
     '',
     DELETED_HEADING,
     '',
@@ -42,7 +50,7 @@ function buildComment() {
     '',
     RESULTS_TABLE_HEADER,
     RESULTS_TABLE_SEPARATOR,
-    ...Array.from({ length: 20 }, (_, i) => resultsRow(i)),
+    ...Array.from({ length: 20 }, (_, i) => i == injectedTableLineIndex ? injectedTableLine : resultsRow(i)),
     '',
   ].join('\n');
 }
@@ -254,5 +262,29 @@ test('splitCommentIntoChunks - every chunk is numbered with its part and the tot
   // Exactly one label per chunk
   for (const chunk of chunks) {
     assert.strictEqual(chunk.split('\n').filter(line => line.startsWith(':open_book: Part ')).length, 1);
+  }
+});
+
+test('splitCommentIntoChunks - no false positive table header separators are detected', () => {
+
+  const dangerousLine = '| Looking for credentials | [See in Explore](https://example.grafana.example/explore?something=---BEGIN RSA PRIVATE KEY---) | 0 | 5.230158 s | 342,526,137 decbytes | 0 |'; // Has the triple dash which might trip up table header separator detection
+
+  const comment = buildCommentWithInjectedLine(
+    dangerousLine,
+    5,
+  );
+  const chunks = splitCommentIntoChunks(comment, COMMENT_IDENTIFIER, 400);
+  assert(chunks.length > 1);
+
+  const chunksWithDangerousLine = chunks.filter(chunk => chunk.includes(dangerousLine));
+  assert.strictEqual(chunksWithDangerousLine.length, 1, 'the dangerous line should appear in exactly one chunk');
+
+  const chunksWithRows = chunks.filter(chunk => chunk.includes('| rule_') || chunk.includes(dangerousLine));
+  assert(chunksWithRows.length > 1, `expected the table to span more than one chunk, got ${chunksWithRows.length}`);
+  for (const chunk of chunksWithRows) {
+    assert(
+      chunk.includes(`${RESULTS_TABLE_HEADER}\n${RESULTS_TABLE_SEPARATOR}`),
+      `chunk without a table header: ${JSON.stringify(chunk)}`,
+    );
   }
 });


### PR DESCRIPTION
Fixes the faulty split of tables if a line is incorrectly detected as a table header separator line. This happens if a line contains something like e.g. `--- BEGIN RSA PRIVATE KEY ---` or similar. As some detection rules might do that looking for token leak or similar.

Fixed by using a more robust regex to determine table header separators instead of just checking for existence of `|` and `---` in a single  line.
Regression test is added aswell.