### PR TITLE
Extend the alert rule annotations with more paths

### DIFF
--- a/internal/integrate/integrator.go
+++ b/internal/integrate/integrator.go
@@ -532,7 +532,7 @@ func (i *Integrator) DoConversions() error {
 			fmt.Printf("Skipping manually-maintained deployment file (not overwriting): %s\n", file)
 			continue
 		}
-		err = i.ConvertToAlert(rule, queries, titles, config, inputFile, conversionObject)
+		err = i.ConvertToAlert(rule, queries, titles, config, inputFile, file, conversionObject)
 		if err != nil {
 			return err
 		}
@@ -599,7 +599,7 @@ func (i *Integrator) SetOutputs() error {
 	return nil
 }
 
-func (i *Integrator) ConvertToAlert(rule *model.ProvisionedAlertRule, queries []string, titles string, config model.ConversionConfig, conversionFile string, conversionObject model.ConversionOutput) error {
+func (i *Integrator) ConvertToAlert(rule *model.ProvisionedAlertRule, queries []string, titles string, config model.ConversionConfig, conversionFile string, integrateFile string, conversionObject model.ConversionOutput) error {
 	datasource := shared.GetConfigValue(config.DataSource, i.config.ConversionDefaults.DataSource, "nil")
 	timewindow := shared.GetConfigValue(config.TimeWindow, i.config.ConversionDefaults.TimeWindow, "1m")
 	duration, err := time.ParseDuration(timewindow)
@@ -696,8 +696,10 @@ func (i *Integrator) ConvertToAlert(rule *model.ProvisionedAlertRule, queries []
 	logSourceType := shared.GetConfigValue(config.Target, i.config.ConversionDefaults.Target, shared.Loki)
 	rule.Annotations["LogSourceType"] = logSourceType
 
-	// Path to associated conversion file
+	// Path to associated files
+	rule.Annotations["SigmaRule"] = conversionObject.InputFile
 	rule.Annotations["ConversionFile"] = conversionFile
+	rule.Annotations["DeploymentFile"] = integrateFile
 
 	funcs := templateFuncs(i.config.IntegratorConfig.TemplateAllRules)
 

--- a/internal/integrate/integrator_test.go
+++ b/internal/integrate/integrator_test.go
@@ -239,6 +239,7 @@ func TestConvertToAlert(t *testing.T) {
 				UID: "",
 			},
 			convObject: model.ConversionOutput{
+				InputFile: "test_sigma_rule.yml",
 				Rules: []model.SigmaRule{
 					{
 						Title:     "A non-title case title",
@@ -278,10 +279,12 @@ func TestConvertToAlert(t *testing.T) {
 			wantAnnotations: map[string]string{
 				"Author":         "John Doe",
 				"ConversionFile": "test_conversion_file.json",
+				"DeploymentFile": "test_integrate_file.json",
 				"LogSourceType":  "loki",
 				"LogSourceUid":   "my_data_source",
 				"Lookback":       "0s",
 				"Query":          "{job=`.+`} | json | test=`true`",
+				"SigmaRule":      "test_sigma_rule.yml",
 				"TimeWindow":     "5m",
 				"summary":        "A Non-Title Case Title",
 				"runbook_url":    "https://my.runbook.url/A_non-title_case_title",
@@ -295,6 +298,7 @@ func TestConvertToAlert(t *testing.T) {
 				UID: "",
 			},
 			convObject: model.ConversionOutput{
+				InputFile: "test_sigma_rule.yml",
 				Rules: []model.SigmaRule{
 					{Level: "low"},
 					{Level: "critical"},
@@ -325,10 +329,12 @@ func TestConvertToAlert(t *testing.T) {
 			},
 			wantAnnotations: map[string]string{
 				"ConversionFile": "test_conversion_file.json",
+				"DeploymentFile": "test_integrate_file.json",
 				"LogSourceType":  "loki",
 				"LogSourceUid":   "my_data_source",
 				"Lookback":       "0s",
 				"Query":          "{job=`.+`} | json | test=`true`",
+				"SigmaRule":      "test_sigma_rule.yml",
 				"TimeWindow":     "5m",
 				"severity":       "critical",
 			},
@@ -395,7 +401,7 @@ func TestConvertToAlert(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			i := NewIntegrator()
 			i.config.IntegratorConfig = tt.integratorConfig
-			err := i.ConvertToAlert(tt.rule, tt.queries, tt.titles, tt.convConfig, "test_conversion_file.json", tt.convObject)
+			err := i.ConvertToAlert(tt.rule, tt.queries, tt.titles, tt.convConfig, "test_conversion_file.json", "test_integrate_file.json", tt.convObject)
 			if tt.wantError {
 				assert.NotNil(t, err)
 			} else {


### PR DESCRIPTION
When viewing SRD alerts, our alert rules only include the path to the conversion output, and not the original Sigma rule file or the alert rule itself. This PR adds them both as annotations, to help simplify identifying these files when necessary.

Adds annotations containing paths pointing to relevant files:
* Sigma rule
* Alert rule