### PR TITLE
Migrate action `uses:` to self-repository syntax

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -7,3 +7,11 @@ paths:
       # Note that this is NOT fixed as of actionlint 1.7.12, so upgrading alone will not remove the need
       # for this. Drop it once a release actually recognises the key, and re-run the check to confirm.
       - 'unexpected key "queue" for "concurrency" section.*'
+
+      # actionlint's schema predates GitHub's `$/` self-repository `uses:` syntax, so it rejects a valid
+      # workflow. Temporary until actionlint learns the syntax. Upstream:
+      #    - issue: https://github.com/rhysd/actionlint/issues/711
+      #    - PR: https://github.com/rhysd/actionlint/pull/732
+      # Not fixed as of actionlint 1.7.12, so upgrading alone will not remove the need for this. Drop it
+      # once a release actually recognises the syntax, and re-run the check to confirm.
+      - 'specifying action "\$/.*" in invalid format because ref is missing.*'

--- a/.github/workflows/convert-integrate.yml
+++ b/.github/workflows/convert-integrate.yml
@@ -150,7 +150,7 @@ jobs:
           fetch-depth: 0
 
       - name: Convert Sigma rules
-        uses: grafana/sigma-rule-deployment/actions/convert@v0.3.1
+        uses: $/actions/convert
         with:
           config_path: ${{ inputs.config_path }}
           plugin_packages: ${{ inputs.plugin_packages }}
@@ -161,7 +161,7 @@ jobs:
           changed_files_from_base: ${{ inputs.changed_files_from_base }}
 
       - name: Integrate queries into alert rules
-        uses: grafana/sigma-rule-deployment/actions/integrate@v0.3.1
+        uses: $/actions/integrate
         with:
           config_path: ${{ inputs.config_path }}
           grafana_sa_token: ${{ secrets.grafana_sa_token || fromJSON(steps.get-secrets.outputs.secrets || '{}').GRAFANA_SA_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Deploy alert rules to Grafana
         id: deploy
-        uses: grafana/sigma-rule-deployment/actions/deploy@v0.3.1
+        uses: $/actions/deploy
         with:
           config_path: ${{ inputs.config_path }}
           fresh_deploy: ${{ inputs.fresh_deploy }}

--- a/README.md
+++ b/README.md
@@ -162,12 +162,8 @@ This repository has [immutable releases](https://docs.github.com/en/code-securit
 When the main branch is in a state that is ready to release, the process is as follows:
 
 1. Determine the correct version number using the [Semantic Versioning](https://semver.org/) methodology. All version numbers should be in the format `\d+\.\d+\.\d+(-[0-9A-Za-z-]+)?`
-2. Create a PR to update **all** the version tags used in the reusable workflows [convert-integrate.yml](.github/workflows/convert-integrate.yml) and [deploy.yml](.github/workflows/deploy.yml) to the new version, and merge it into `main` once it is approved, e.g.:
-```
-        uses: grafana/sigma-rule-deployment/actions/convert@vX.X.X
-```
-3. Checkout `main` and create a signed tag for the release, named the version number prefixed with a v, e.g., `git tag --sign --message="Release vX.X.X" vX.X.X`
-4. Push the tag to GitHub, e.g., `git push --tags`. This triggers the ["SBOM on Release"](.github/workflows/sbom-release.yml) workflow, which exports the SPDX SBOM from Socket, creates a **draft** release with auto-generated notes, and attaches the SBOM as the `sigma-rule-deployment-vX.X.X.spdx.json` asset. The release is automatically marked as a pre-release when the tag starts with `v0.` or has a `-alpha/beta/rcX` suffix.
-5. Open the auto-created **draft** release in GitHub. Review and adjust the generated release notes, confirm the pre-release flag is correct, and check that the `.spdx.json` SBOM asset is attached. (The SBOM must be present now, because immutable releases prevent adding assets after publishing.)
-6. Publish the draft release.
-7. Validate that the ["Build & Integration Test Image"](.github/workflows/build-docker.yml) action, which pushes the tagged image to the GitHub Container Registry (GHCR) on publish, has completed successfully for the release.
+2. Checkout `main` and create a signed tag for the release, named the version number prefixed with a v, e.g., `git tag --sign --message="Release vX.X.X" vX.X.X`
+3. Push the tag to GitHub, e.g., `git push --tags`. This triggers the ["SBOM on Release"](.github/workflows/sbom-release.yml) workflow, which exports the SPDX SBOM from Socket, creates a **draft** release with auto-generated notes, and attaches the SBOM as the `sigma-rule-deployment-vX.X.X.spdx.json` asset. The release is automatically marked as a pre-release when the tag starts with `v0.` or has a `-alpha/beta/rcX` suffix.
+4. Open the auto-created **draft** release in GitHub. Review and adjust the generated release notes, confirm the pre-release flag is correct, and check that the `.spdx.json` SBOM asset is attached. (The SBOM must be present now, because immutable releases prevent adding assets after publishing.)
+5. Publish the draft release.
+6. Validate that the ["Build & Integration Test Image"](.github/workflows/build-docker.yml) action, which pushes the tagged image to the GitHub Container Registry (GHCR) on publish, has completed successfully for the release.


### PR DESCRIPTION
As announced in [this GitHub blog post](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/), GitHub now supports relative references for actions in the same repository. We can use this to reduces toil for releasing new versions and avoid pinning actions to a tag.

Sadly, `actionlint` doesn't support this syntax (hasn't been updated in six month :grimacing:) and therefore we need to add an exclusions for it.